### PR TITLE
Multi instrument support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 out/
 bin/
+data/
 
 .idea/
 cmake-build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,3 @@ target_include_directories( ton_app PRIVATE
 )
 
 target_link_libraries(ton_app PRIVATE antlr4_static)
-
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(HEADERS
     include/listener/TonDeclarationListener.h
     include/listener/TonSyntaxErrorListener.h
     include/core/MusicBase.h
+    include/core/tsf.h
     include/core/Scope.h
     include/core/Timeline.h
 )
@@ -41,3 +42,6 @@ target_include_directories( ton_app PRIVATE
 )
 
 target_link_libraries(ton_app PRIVATE antlr4_static)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/Ton.g4
+++ b/Ton.g4
@@ -72,6 +72,7 @@ audioOpStat
     | MUTE target SEMI
     | UNMUTE (target | ALL) SEMI
     | TRASH target SEMI
+    | target VOL expr SEMI
     ;
 
 saveStat : EXCLAM_MARK SAVE expr STRING_VAL SEMI ;
@@ -86,7 +87,7 @@ type : TYPE_BOOL | TYPE_INT | TYPE_NUM | TYPE_CHAR | TYPE_STRING
 expr
     : L_BRACKET (expr (COMMA expr)*)? R_BRACKET                # ArrayExpr
     | ID L_PAREN (expr (COMMA expr)*)? R_PAREN                 # FunctionCallExpr
-    | ID expr expr                                             # CreateSoundExpr
+    | ID expr expr expr?                                       # CreateSoundExpr
     | expr (AS STRING_VAL)? AT expr                            # TrackEventExpr
     | expr L_BRACKET expr R_BRACKET                            # IndexExpr    
     | expr L_BRACKET expr COLON expr R_BRACKET                 # SliceExpr    
@@ -159,6 +160,7 @@ MUTE           : 'MUTE' ;
 UNMUTE         : 'UNMUTE' ;
 DIVIDE         : 'DIVIDE' ;
 EMPTYSOUND     : 'EMPTYSOUND' ;
+VOL            : 'VOL' ;
 
 ASSIGN         : '<-' ; 
 ADD_ASSIGN     : '+<-' ;

--- a/examples/Music_examples/example6.txt
+++ b/examples/Music_examples/example6.txt
@@ -2,16 +2,18 @@ $______________________________________________
 $
 $ PROGRAM 6: Space Arpeggio 
 $______________________________________________
+USE bass;
+USE piano;
+USE guitar;
 
-
-!make SOUND bassC <- synth C2 2000;
-!make SOUND bassF <- synth F2 2000;
-!make SOUND n1 <- synth C4 250;
-!make SOUND n2 <- synth E4 250;
-!make SOUND n3 <- synth G4 250;
-!make SOUND n4 <- synth B4 250;
-!make SOUND n5 <- synth A4 250;
-!make SOUND n6 <- synth F4 250;
+!make SOUND bassC <- bass C2 2000;
+!make SOUND bassF <- bass F2 2000;
+!make SOUND n1 <- piano C4 250;
+!make SOUND n2 <- piano E4 250;
+!make SOUND n3 <- piano G4 250;
+!make SOUND n4 <- guitar B4 250;
+!make SOUND n5 <- guitar A4 250;
+!make SOUND n6 <- guitar F4 250;
 
 !make TIMELINE song;
 
@@ -48,4 +50,4 @@ song.arp <- [
     n2 AT 3750
 ];
 
-!save song "space_hit.wav";
+!save song "space_hit2.wav";

--- a/examples/Music_examples/example_vol.ton
+++ b/examples/Music_examples/example_vol.ton
@@ -1,0 +1,17 @@
+USE piano;
+
+!make SOUND quiet <- piano G4 1000 0.5;
+
+!make SOUND loud <- piano G4 1000 2;
+loud <- loud * 0.25;
+!make TIMELINE final;
+
+final NEW TRACK first;
+final.first <- [quiet AT 0, loud AT 1200];
+
+final NEW TRACK second;
+final.second <- [quiet AT 2200, loud AT 3200];
+
+final.second VOL 10;
+
+!save final "vol.wav";

--- a/examples/Music_examples/harder.ton
+++ b/examples/Music_examples/harder.ton
@@ -1,0 +1,103 @@
+USE cello;
+USE piano;
+USE guitar;
+
+$// ==========================================
+$// 1. DEFINICJE DŹWIĘKÓW (SOUNDS)
+$// ==========================================
+
+$// --- Fundament basowy (Cello - trwający 2 sekundy na akord) ---
+!make SOUND bassA <- cello A2 2000;
+!make SOUND bassF <- cello F2 2000;
+!make SOUND bassC <- cello C3 2000;
+!make SOUND bassG <- cello G2 2000;
+
+$// --- Fortepianowe Arpeggia (Szybkie nuty po 250ms) ---
+$// Akord Am (A-C-E)
+!make SOUND pA <- piano A4 250;
+!make SOUND pC <- piano C5 250;
+!make SOUND pE <- piano E5 250;
+
+$// Akord F (F-A-C)
+!make SOUND pF <- piano F4 250;
+$// (pA i pC mamy już zdefiniowane wyżej!)
+
+$ Akord C (C-E-G)
+!make SOUND pClow <- piano C4 250;
+!make SOUND pElow <- piano E4 250;
+!make SOUND pGlow <- piano G4 250;
+
+$ Akord G (G-B-D)
+!make SOUND pG <- piano G4 250;
+!make SOUND pB <- piano B4 250;
+!make SOUND pD <- piano D5 250;
+
+$  --- Melodia główna (Flet - różne długości) ---
+!make SOUND mE5_long <- guitar E5 1000;
+!make SOUND mD5_short <- guitar D5 500;
+!make SOUND mC5_short <- guitar C5 500;
+
+!make SOUND mA5_long <- guitar A5 1000;
+!make SOUND mG5_short <- guitar G5 500;
+!make SOUND mF5_short <- guitar F5 500;
+
+!make SOUND mG5_long <- guitar G5 1000;
+!make SOUND mF5_short2 <- guitar F5 500;
+!make SOUND mE5_short <- guitar E5 500;
+
+!make SOUND mD5_long <- guitar D5 2000;
+
+
+$ ==========================================
+$ 2. ARANŻACJA (TIMELINE)
+$==========================================
+
+!make TIMELINE cinematic;
+
+$ --- Ścieżka 1: Bas ---
+cinematic NEW TRACK bass;
+cinematic.bass <- [
+    bassA AT 0,
+    bassF AT 2000,
+    bassC AT 4000,
+    bassG AT 6000
+];
+
+$ --- Ścieżka 2: Arpeggiator ---
+cinematic NEW TRACK piano_arp;
+cinematic.piano_arp <- [
+    $ Am (0 - 2000ms)
+    pA AT 0, pC AT 250, pE AT 500, pA AT 750,
+    pC AT 1000, pE AT 1250, pC AT 1500, pA AT 1750,
+
+    $ F (2000 - 4000ms)
+    pF AT 2000, pA AT 2250, pC AT 2500, pF AT 2750,
+    pA AT 3000, pC AT 3250, pA AT 3500, pF AT 3750,
+
+    $ C (4000 - 6000ms)
+    pClow AT 4000, pElow AT 4250, pGlow AT 4500, pClow AT 4750,
+    pElow AT 5000, pGlow AT 5250, pElow AT 5500, pClow AT 5750,
+
+    $ G (6000 - 8000ms)
+    pG AT 6000, pB AT 6250, pD AT 6500, pG AT 6750,
+    pB AT 7000, pD AT 7250, pB AT 7500, pG AT 7750
+];
+
+$ --- Ścieżka 3: Solówka na flecie ---
+$ cinematic NEW TRACK melody;
+$ cinematic.melody <- [
+$     $/ Am
+$     mE5_long AT 0, mD5_short AT 1000, mC5_short AT 1500,
+$     $ F
+$     mA5_long AT 2000, mG5_short AT 3000, mF5_short AT 3500,
+$     $ C
+$     mG5_long AT 4000, mF5_short2 AT 5000, mE5_short AT 5500,
+$     $ G
+$     mD5_long AT 6000
+$ ];
+
+
+$ ==========================================
+$ 3. EXPORT
+$ ==========================================
+!save cinematic "cinematic_journey.wav";

--- a/examples/Music_examples/harder.ton
+++ b/examples/Music_examples/harder.ton
@@ -84,17 +84,17 @@ cinematic.piano_arp <- [
 ];
 
 $ --- Ścieżka 3: Solówka na flecie ---
-$ cinematic NEW TRACK melody;
-$ cinematic.melody <- [
-$     $/ Am
-$     mE5_long AT 0, mD5_short AT 1000, mC5_short AT 1500,
-$     $ F
-$     mA5_long AT 2000, mG5_short AT 3000, mF5_short AT 3500,
-$     $ C
-$     mG5_long AT 4000, mF5_short2 AT 5000, mE5_short AT 5500,
-$     $ G
-$     mD5_long AT 6000
-$ ];
+cinematic NEW TRACK melody;
+cinematic.melody <- [
+    $/ Am
+    mE5_long AT 0, mD5_short AT 1000, mC5_short AT 1500,
+    $ F
+    mA5_long AT 2000, mG5_short AT 3000, mF5_short AT 3500,
+    $ C
+    mG5_long AT 4000, mF5_short2 AT 5000, mE5_short AT 5500,
+    $ G
+    mD5_long AT 6000
+];
 
 
 $ ==========================================

--- a/examples/Music_examples/herecomesthesun.ton
+++ b/examples/Music_examples/herecomesthesun.ton
@@ -1,0 +1,113 @@
+USE guitar;
+USE bass;
+
+$ ==========================================
+$ 1. DEFINICJE DZWIEKOW (Oryginalne A-dur)
+$ ==========================================
+$ Tempo: 1 uderzenie (cwiercnuta) = 500ms
+
+$ --- BASS (Niski fundament) ---
+!make SOUND bA <- bass A2 2000;
+!make SOUND bD <- bass D3 2000;
+!make SOUND bE <- bass E3 2000;
+
+$ --- GITARA AKUSTYCZNA 1 (Bicie akordowe po 500ms) ---
+$ Akord A-dur
+!make SOUND cA1 <- guitar A3 500;
+!make SOUND cA2 <- guitar C#4 500;
+!make SOUND cA3 <- guitar E4 500;
+
+$ Akord D-dur
+!make SOUND cD1 <- guitar D4 500;
+!make SOUND cD2 <- guitar F#4 500;
+!make SOUND cD3 <- guitar A4 500;
+
+$ Akord E7
+!make SOUND cE1 <- guitar E4 500;
+!make SOUND cE2 <- guitar G#4 500;
+!make SOUND cE3 <- guitar D5 500;
+
+$ --- GITARA AKUSTYCZNA 2 (Melodia wiodaca) ---
+$ Cwiercnuty (500ms)
+!make SOUND mCs5_q <- guitar C#5 500;
+!make SOUND mB4_q  <- guitar B4 500;
+!make SOUND mA4_q  <- guitar A4 500;
+!make SOUND mD5_q  <- guitar D5 500;
+!make SOUND mE5_q  <- guitar E5 500;
+
+$ Osemki (250ms)
+!make SOUND mA4_e  <- guitar A4 250;
+!make SOUND mB4_e  <- guitar B4 250;
+!make SOUND mCs5_e <- guitar C#5 250;
+!make SOUND mFs4_e <- guitar F#4 250;
+
+$ ==========================================
+$ 2. ARANZACJA TIMELINE
+$ ==========================================
+!make TIMELINE sun_acoustic;
+
+$ --- SCIEZKA 1: BAS ---
+sun_acoustic NEW TRACK bass;
+sun_acoustic.bass <- [
+    bA AT 0,
+    bD AT 2000,
+    bA AT 4000,
+    bD AT 6000,
+    bE AT 8000,
+    bA AT 10000
+];
+
+$ --- SCIEZKA 2: GITARA RYTMICZNA (Podklad) ---
+sun_acoustic NEW TRACK chords;
+sun_acoustic.chords <- [
+    $ Takt 1 i 2 (A-dur)
+    cA1 AT 0, cA2 AT 0, cA3 AT 0,
+    cA1 AT 1000, cA2 AT 1000, cA3 AT 1000,
+    
+    $ Takt 3 (D-dur)
+    cD1 AT 2000, cD2 AT 2000, cD3 AT 2000,
+    cD1 AT 3000, cD2 AT 3000, cD3 AT 3000,
+    
+    $ Takt 4 (A-dur)
+    cA1 AT 4000, cA2 AT 4000, cA3 AT 4000,
+    cA1 AT 5000, cA2 AT 5000, cA3 AT 5000,
+    
+    $ Takt 5 (D-dur)
+    cD1 AT 6000, cD2 AT 6000, cD3 AT 6000,
+    cD1 AT 7000, cD2 AT 7000, cD3 AT 7000,
+    
+    $ Takt 6 (E7)
+    cE1 AT 8000, cE2 AT 8000, cE3 AT 8000,
+    cE1 AT 9000, cE2 AT 9000, cE3 AT 9000,
+    
+    $ Takt 7 (Powrot do A)
+    cA1 AT 10000, cA2 AT 10000, cA3 AT 10000
+];
+
+$ --- SCIEZKA 3: GITARA SOLOWA (Melodia) ---
+sun_acoustic NEW TRACK melody;
+sun_acoustic.melody <- [
+    $ "Here comes the"
+    mCs5_q AT 500, mB4_q AT 1000, mCs5_q AT 1500,
+    
+    $ "sun, doo da doo doo"
+    mA4_q AT 2000, mFs4_e AT 2750, mB4_e AT 3000, mA4_e AT 3250, mB4_e AT 3500,
+    
+    $ "Here comes the"
+    mCs5_q AT 4500, mB4_q AT 5000, mCs5_q AT 5500,
+    
+    $ "sun, and I say"
+    mA4_q AT 6000, mA4_e AT 6750, mB4_q AT 7000, mA4_q AT 7500,
+    
+    $ "It's all right"
+    mCs5_q AT 8500, mB4_q AT 9000, mA4_q AT 9500,
+    
+    $ Zagrywka Harrisona
+    mFs4_e AT 10000, mA4_e AT 10250, mB4_e AT 10500, mA4_e AT 10750,
+    mE5_q AT 11000, mD5_q AT 11500, mCs5_q AT 12000
+];
+
+$ ==========================================
+$ 3. EXPORT
+$ ==========================================
+!save sun_acoustic "sun_acoustic.wav";

--- a/examples/Music_examples/playground.ton
+++ b/examples/Music_examples/playground.ton
@@ -1,0 +1,23 @@
+USE piano;
+USE overdrive;
+USE violin;
+
+!make SOUND p1 <- piano A4 500;
+!make SOUND g1 <- overdrive A4 500;
+!make SOUND v1 <- violin A4 500;
+p1 <- p1 * 16;
+!make SOUND gv <- (p1 + p1);
+!make TIMELINE a;
+
+a NEW TRACK single;
+a.single <- [
+    p1 AS "aaa" AT 0 
+];
+
+a NEW TRACK mixed;
+a.mixed <- [
+    (violin A4 500) AS "violin" AT 1000
+    $ p1 AT 1100
+];
+
+!save a "timeline.wav";

--- a/examples/Music_examples/simplest.ton
+++ b/examples/Music_examples/simplest.ton
@@ -1,0 +1,10 @@
+USE piano;
+USE cello;
+!make SOUND x <- cello C4 500;
+!make SOUND y <- cello D4 500;
+!make SOUND z <- cello E4 500;
+!make SOUND e <- cello F4 500;
+!make SOUND f <- cello G4 500;
+!make SOUND g <- cello B4 500;
+!make SOUND h <- cello C5 500;
+!save (x & y & z & e & f & g & h) "song.wav";

--- a/examples/Music_examples/simplest.ton
+++ b/examples/Music_examples/simplest.ton
@@ -1,5 +1,18 @@
 USE piano;
 USE cello;
+
+!make ARRAY notes <- [C4, D4, E4, F4, G4, B4, C5];
+
+$ WONT WORK FOR NOW -> LACK OF ARRAY INDEXING
+!make SOUND octaveOnCello;
+!save octaveOnCello "test.wav";
+!loop <INT i FROM 0 TO 6> {
+    !make SOUND tmp <- cello notes[i] 500;
+    octaveOnCello <- octaveOnCello & tmp;
+}
+!save octaveOnCello "octave.wav";
+
+
 !make SOUND x <- cello C4 500;
 !make SOUND y <- cello D4 500;
 !make SOUND z <- cello E4 500;
@@ -7,4 +20,4 @@ USE cello;
 !make SOUND f <- cello G4 500;
 !make SOUND g <- cello B4 500;
 !make SOUND h <- cello C5 500;
-!save (x & y & z & e & f & g & h) "song.wav";
+!save (x & y & z & e & f & g & h) "octave.wav";

--- a/include/core/MusicBase.h
+++ b/include/core/MusicBase.h
@@ -4,11 +4,28 @@
 #include "AudioFile.h"
 #include <map>
 
-struct Instrument {
+enum class InstrumentType {
+    SoundFont,
+    RawSample, // For now we leave that
+    Synth      // Built-in synth function (eg Sine Wave)
+};
+
+class Instrument {
+private:
     std::string name;
+
+    InstrumentType type;
+
     std::vector<double> sampleData;
-    // Tutaj w przyszłości można dodać wskaźnik do mapy sampli
-    Instrument(std::string n) : name(n) {}
+
+    // something for SoundFont (?)
+    int midiPresetIndex = -1;
+
+public:
+    Instrument(std::string n) : name{n}, type{InstrumentType::Synth} {}
+
+    Instrument(std::string n, int preset) : name{n}, type{InstrumentType::SoundFont}, midiPresetIndex{preset} {}
+
     Instrument(std::string n, std::string filePath) : name(n) {
         AudioFile<double> audioFile;
         if (audioFile.load(filePath)) {
@@ -18,13 +35,22 @@ struct Instrument {
             std::cerr << ">>> [ERROR] Could not load sample: " << filePath << "\n";
         }
     }
-    Instrument() : name("SineWave") {}
+
+    inline std::string getName() const {
+        return this->name;
+    }
+    inline InstrumentType getType() const {
+        return this->type;
+    }
+    inline int getMidiPresetIndex() const {
+        return this->midiPresetIndex;
+    }
 };
 
 
 struct Note {
     std::string pitchClass; 
-    int octave;            
+    int octave;
 
     Note(std::string p, int o) {
         pitchClass = p;
@@ -35,28 +61,79 @@ struct Note {
         pitchClass = "C";
         octave = 4;
     }
+    inline static const std::map<std::string, int> pitchToSemitone = {
+        {"C", -9}, {"C#", -8}, {"Db", -8}, {"D", -7}, {"D#", -6}, {"Eb", -6},
+        {"E", -5}, {"F", -4}, {"F#", -3}, {"Gb", -3}, {"G", -2}, {"G#", -1},
+        {"Ab", -1}, {"A", 0}, {"A#", 1}, {"Bb", 1}, {"B", 2}
+    };
+
+    int getOffsetFromA4() const {
+        int semitoneOffset = 0;
+        auto it = pitchToSemitone.find(pitchClass);
+        if (it != pitchToSemitone.end()) {
+            semitoneOffset = it->second;
+        }
+
+        int octaveOffset = (octave - 4) * 12;
+        return semitoneOffset + octaveOffset;
+    }
 
     double getFrequency() const {
-        std::map<std::string, int> pitchToSemitone = {
-            {"C", -9}, {"C#", -8}, {"Db", -8}, {"D", -7}, {"D#", -6}, {"Eb", -6},
-            {"E", -5}, {"F", -4}, {"F#", -3}, {"Gb", -3}, {"G", -2}, {"G#", -1},
-            {"Ab", -1}, {"A", 0}, {"A#", 1}, {"Bb", 1}, {"B", 2}
-        };
-        
-        int semitoneOffset = pitchToSemitone[pitchClass];
-        int octaveOffset = (octave - 4) * 12;
-        int totalOffset = semitoneOffset + octaveOffset;
-        
-        return 440.0 * std::pow(2.0, totalOffset / 12.0);
+        return 440.0 * std::pow(2.0, getOffsetFromA4() / 12.0);
+    }
+
+    int toMidiNumber() const {
+        // Nuta A4 to w standardzie MIDI numer 69.
+        // Środkowe C4 to numer 60 (69 - 9).
+        return 69 + getOffsetFromA4();
     }
 };
 
 
-struct Sound {
-    std::vector<double> samples;
-    int sampleRate = 44100;
+class Sound {
+public:
+    std::vector<float> samples;
 
+    void generateSineWave(Note note, int durationMs) {
+        samples.clear();
+        int totalSamples = (durationMs / 1000.0) * sampleRate;
+        samples.reserve(totalSamples);
+        for (int i = 0; i < totalSamples; ++i) {
+            double time = (double)i / sampleRate;
+            double sampleValue = std::sin(2.0 * M_PI * note.getFrequency() * time);
+            samples.push_back(sampleValue);
+        }
+    }
+    void generateSawWave(Note note, int durationMs) {
+        // TODO
+        samples.clear();
+        return;
+    }
+    void generateSquareWave(Note note, int durationMs) {
+        // TODO
+        samples.clear();
+        return;
+    }
+
+public:
+    static constexpr int sampleRate = 44100;
+    void generateSynthWave(std::string synthName, Note note, int durationMs) {
+        if (synthName == "sine") {
+            this->generateSineWave(note, durationMs);
+        }
+        else if (synthName == "saw") {
+            this->generateSawWave(note, durationMs);
+        }
+        else if (synthName == "square") {
+            this->generateSawWave(note, durationMs);
+        }
+        else {
+            throw std::runtime_error("no such synth");
+        }
+    }
     Sound() {}
+
+
 };
 
 

--- a/include/core/MusicBase.h
+++ b/include/core/MusicBase.h
@@ -131,9 +131,41 @@ public:
             throw std::runtime_error("no such synth");
         }
     }
+
+    float getLargestValue() const {
+        float maxValue = 0;
+        for (const auto& val : samples) {
+            float currentValue = std::abs(val);
+            if (currentValue > maxValue) {
+                maxValue = currentValue;
+            }
+        }
+        return maxValue;
+    }
+
+    void normalize() {
+        float value = this->getLargestValue();
+        if (value > 0.0f && value != 1.0f) {
+            for (auto& x : samples) {
+                x /= value;
+            }
+        }
+    }
+
+    Sound operator*(double multiplier) const {
+        Sound amplifiedSound;
+        amplifiedSound.samples.reserve(this->samples.size());
+        for (float val : this->samples) {
+            amplifiedSound.samples.push_back(static_cast<float>(val * multiplier));
+        }
+        return amplifiedSound;
+    }
+
     Sound() {}
-
-
 };
+
+inline Sound operator*(double multiplier, const Sound& sound) {
+    return sound.operator*(multiplier);
+}
 
 

--- a/include/core/Timeline.h
+++ b/include/core/Timeline.h
@@ -14,9 +14,44 @@ struct Track {
     std::string name;
     std::vector<TrackEvent> events;
     bool isMuted = false;
+    float volume = 1.0f;
 };
 
 struct Timeline {
     std::string name;
-    std::map<std::string, Track> tracks;
+    std::unordered_map<std::string, Track> tracks;
+
+
+    Sound renderFinalSound() const {
+        Sound resultSound;
+        int maxSamples = Sound::sampleRate;
+
+        for (const auto& [trackName, track] : tracks) {
+            if (track.isMuted) {
+                continue;
+            }
+            for (const auto& ev : track.events) {
+                int endSample = (ev.startTimeMs / 1000.0) * Sound::sampleRate + ev.sound.samples.size();
+                if (endSample > maxSamples) {
+                    maxSamples = endSample;
+                }
+            }
+        }
+
+        resultSound.samples.assign(maxSamples, 0.0f);
+
+        for (const auto& [trackName, track] : tracks) {
+            if (track.isMuted) {
+                continue;
+            }
+            for (const auto& ev : track.events) {
+                int startSample = (ev.startTimeMs / 1000.0) * Sound::sampleRate;
+                for (size_t i = 0; i < ev.sound.samples.size(); ++i) {
+
+                    resultSound.samples[startSample + i] += ev.sound.samples[i] * track.volume;
+                }
+            }
+        }
+        return resultSound;
+    }
 };

--- a/include/core/tsf.h
+++ b/include/core/tsf.h
@@ -1,0 +1,2079 @@
+/* TinySoundFont - v0.9 - SoundFont2 synthesizer - https://github.com/schellingb/TinySoundFont
+                                     no warranty implied; use at your own risk
+   Do this:
+      #define TSF_IMPLEMENTATION
+   before you include this file in *one* C or C++ file to create the implementation.
+   // i.e. it should look like this:
+   #include ...
+   #include ...
+   #define TSF_IMPLEMENTATION
+   #include "tsf.h"
+
+   [OPTIONAL] #define TSF_NO_STDIO to remove stdio dependency
+   [OPTIONAL] #define TSF_MALLOC, TSF_REALLOC, and TSF_FREE to avoid stdlib.h
+   [OPTIONAL] #define TSF_MEMCPY, TSF_MEMSET to avoid string.h
+   [OPTIONAL] #define TSF_POW, TSF_POWF, TSF_EXPF, TSF_LOG, TSF_TAN, TSF_LOG10, TSF_SQRT to avoid math.h
+
+   NOT YET IMPLEMENTED
+     - Support for ChorusEffectsSend and ReverbEffectsSend generators
+     - Better low-pass filter without lowering performance too much
+     - Support for modulators
+
+   LICENSE (MIT)
+
+   Copyright (C) 2017-2025 Bernhard Schelling
+   Based on SFZero, Copyright (C) 2012 Steve Folta (https://github.com/stevefolta/SFZero)
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy of this
+   software and associated documentation files (the "Software"), to deal in the Software
+   without restriction, including without limitation the rights to use, copy, modify, merge,
+   publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+   to whom the Software is furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+   PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+   LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#ifndef TSF_INCLUDE_TSF_INL
+#define TSF_INCLUDE_TSF_INL
+
+#ifdef __cplusplus
+extern "C" {
+#  define CPP_DEFAULT0 = 0
+#else
+#  define CPP_DEFAULT0
+#endif
+
+//define this if you want the API functions to be static
+#ifdef TSF_STATIC
+#define TSFDEF static
+#else
+#define TSFDEF extern
+#endif
+
+// The load functions will return a pointer to a struct tsf which all functions
+// thereafter take as the first parameter.
+// On error the tsf_load* functions will return NULL most likely due to invalid
+// data (or if the file did not exist in tsf_load_filename).
+typedef struct tsf tsf;
+
+#ifndef TSF_NO_STDIO
+// Directly load a SoundFont from a .sf2 file path
+TSFDEF tsf* tsf_load_filename(const char* filename);
+#endif
+
+// Load a SoundFont from a block of memory
+TSFDEF tsf* tsf_load_memory(const void* buffer, int size);
+
+// Stream structure for the generic loading
+struct tsf_stream
+{
+	// Custom data given to the functions as the first parameter
+	void* data;
+
+	// Function pointer will be called to read 'size' bytes into ptr (returns number of read bytes)
+	int (*read)(void* data, void* ptr, unsigned int size);
+
+	// Function pointer will be called to skip ahead over 'count' bytes (returns 1 on success, 0 on error)
+	int (*skip)(void* data, unsigned int count);
+};
+
+// Generic SoundFont loading method using the stream structure above
+TSFDEF tsf* tsf_load(struct tsf_stream* stream);
+
+// Copy a tsf instance from an existing one, use tsf_close to close it as well.
+// All copied tsf instances and their original instance are linked, and share the underlying soundfont.
+// This allows loading a soundfont only once, but using it for multiple independent playbacks.
+// (This function isn't thread-safe without locking.)
+TSFDEF tsf* tsf_copy(tsf* f);
+
+// Free the memory related to this tsf instance
+TSFDEF void tsf_close(tsf* f);
+
+// Stop all playing notes immediately and reset all channel parameters
+TSFDEF void tsf_reset(tsf* f);
+
+// Returns the preset index from a bank and preset number, or -1 if it does not exist in the loaded SoundFont
+TSFDEF int tsf_get_presetindex(const tsf* f, int bank, int preset_number);
+
+// Returns the number of presets in the loaded SoundFont
+TSFDEF int tsf_get_presetcount(const tsf* f);
+
+// Returns the name of a preset index >= 0 and < tsf_get_presetcount()
+TSFDEF const char* tsf_get_presetname(const tsf* f, int preset_index);
+
+// Returns the name of a preset by bank and preset number
+TSFDEF const char* tsf_bank_get_presetname(const tsf* f, int bank, int preset_number);
+
+// Supported output modes by the render methods
+enum TSFOutputMode
+{
+	// Two channels with single left/right samples one after another
+	TSF_STEREO_INTERLEAVED,
+	// Two channels with all samples for the left channel first then right
+	TSF_STEREO_UNWEAVED,
+	// A single channel (stereo instruments are mixed into center)
+	TSF_MONO
+};
+
+// Thread safety:
+//
+// 1. Rendering / voices:
+//
+// Your audio output which calls the tsf_render* functions will most likely
+// run on a different thread than where the playback tsf_note* functions
+// are called. In which case some sort of concurrency control like a
+// mutex needs to be used so they are not called at the same time.
+// Alternatively, you can pre-allocate a maximum number of voices that can
+// play simultaneously by calling tsf_set_max_voices after loading.
+// That way memory re-allocation will not happen during tsf_note_on and
+// TSF should become mostly thread safe.
+// There is a theoretical chance that ending notes would negatively influence
+// a voice that is rendering at the time but it is hard to say.
+// Also be aware, this has not been tested much.
+//
+// 2. Channels:
+//
+// Calls to tsf_channel_set_... functions may allocate new channels
+// if no channel with that number was previously used. Make sure to
+// create all channels at the beginning as required if you call tsf_render*
+// from a different thread.
+
+// Setup the parameters for the voice render methods
+//   outputmode: if mono or stereo and how stereo channel data is ordered
+//   samplerate: the number of samples per second (output frequency)
+//   global_gain_db: volume gain in decibels (>0 means higher, <0 means lower)
+TSFDEF void tsf_set_output(tsf* f, enum TSFOutputMode outputmode, int samplerate, float global_gain_db CPP_DEFAULT0);
+
+// Set the global gain as a volume factor
+//   global_gain: the desired volume where 1.0 is 100%
+TSFDEF void tsf_set_volume(tsf* f, float global_gain);
+
+// Set the maximum number of voices to play simultaneously
+// Depending on the soundfond, one note can cause many new voices to be started,
+// so don't keep this number too low or otherwise sounds may not play.
+//   max_voices: maximum number to pre-allocate and set the limit to
+//   (tsf_set_max_voices returns 0 if allocation failed, otherwise 1)
+TSFDEF int tsf_set_max_voices(tsf* f, int max_voices);
+
+// Start playing a note
+//   preset_index: preset index >= 0 and < tsf_get_presetcount()
+//   key: note value between 0 and 127 (60 being middle C)
+//   vel: velocity as a float between 0.0 (equal to note off) and 1.0 (full)
+//   bank: instrument bank number (alternative to preset_index)
+//   preset_number: preset number (alternative to preset_index)
+//   (tsf_note_on returns 0 if the allocation of a new voice failed, otherwise 1)
+//   (tsf_bank_note_on returns 0 if preset does not exist or allocation failed, otherwise 1)
+TSFDEF int tsf_note_on(tsf* f, int preset_index, int key, float vel);
+TSFDEF int tsf_bank_note_on(tsf* f, int bank, int preset_number, int key, float vel);
+
+// Stop playing a note
+//   (bank_note_off returns 0 if preset does not exist, otherwise 1)
+TSFDEF void tsf_note_off(tsf* f, int preset_index, int key);
+TSFDEF int  tsf_bank_note_off(tsf* f, int bank, int preset_number, int key);
+
+// Stop playing all notes (end with sustain and release)
+TSFDEF void tsf_note_off_all(tsf* f);
+
+// Returns the number of active voices
+TSFDEF int tsf_active_voice_count(tsf* f);
+
+// Render output samples into a buffer
+// You can either render as signed 16-bit values (tsf_render_short) or
+// as 32-bit float values (tsf_render_float)
+//   buffer: target buffer of size samples * output_channels * sizeof(type)
+//   samples: number of samples to render
+//   flag_mixing: if 0 clear the buffer first, otherwise mix into existing data
+TSFDEF void tsf_render_short(tsf* f, short* buffer, int samples, int flag_mixing CPP_DEFAULT0);
+TSFDEF void tsf_render_float(tsf* f, float* buffer, int samples, int flag_mixing CPP_DEFAULT0);
+
+// Higher level channel based functions, set up channel parameters
+//   channel: channel number
+//   preset_index: preset index >= 0 and < tsf_get_presetcount()
+//   preset_number: preset number (alternative to preset_index)
+//   flag_mididrums: 0 for normal channels, otherwise apply MIDI drum channel rules
+//   bank: instrument bank number (alternative to preset_index)
+//   pan: stereo panning value from 0.0 (left) to 1.0 (right) (default 0.5 center)
+//   volume: linear volume scale factor (default 1.0 full)
+//   pitch_wheel: pitch wheel position 0 to 16383 (default 8192 unpitched)
+//   pitch_range: range of the pitch wheel in semitones (default 2.0, total +/- 2 semitones)
+//   tuning: tuning of all playing voices in semitones (default 0.0, standard (A440) tuning)
+//   flag_sustain: 0 to end notes that were held sustained and disable holding sustain otherwise enable it
+//   (tsf_set_preset_number and set_bank_preset return 0 if preset does not exist, otherwise 1)
+//   (tsf_channel_set_... return 0 if a new channel needed allocation and that failed, otherwise 1)
+TSFDEF int tsf_channel_set_presetindex(tsf* f, int channel, int preset_index);
+TSFDEF int tsf_channel_set_presetnumber(tsf* f, int channel, int preset_number, int flag_mididrums CPP_DEFAULT0);
+TSFDEF int tsf_channel_set_bank(tsf* f, int channel, int bank);
+TSFDEF int tsf_channel_set_bank_preset(tsf* f, int channel, int bank, int preset_number);
+TSFDEF int tsf_channel_set_pan(tsf* f, int channel, float pan);
+TSFDEF int tsf_channel_set_volume(tsf* f, int channel, float volume);
+TSFDEF int tsf_channel_set_pitchwheel(tsf* f, int channel, int pitch_wheel);
+TSFDEF int tsf_channel_set_pitchrange(tsf* f, int channel, float pitch_range);
+TSFDEF int tsf_channel_set_tuning(tsf* f, int channel, float tuning);
+TSFDEF int tsf_channel_set_sustain(tsf* f, int channel, int flag_sustain);
+
+// Start or stop playing notes on a channel (needs channel preset to be set)
+//   channel: channel number
+//   key: note value between 0 and 127 (60 being middle C)
+//   vel: velocity as a float between 0.0 (equal to note off) and 1.0 (full)
+//   (tsf_channel_note_on returns 0 on allocation failure of new voice, otherwise 1)
+TSFDEF int tsf_channel_note_on(tsf* f, int channel, int key, float vel);
+TSFDEF void tsf_channel_note_off(tsf* f, int channel, int key);
+TSFDEF void tsf_channel_note_off_all(tsf* f, int channel); //end with sustain and release
+TSFDEF void tsf_channel_sounds_off_all(tsf* f, int channel); //end immediately
+
+// Apply a MIDI control change to the channel (not all controllers are supported!)
+//    (tsf_channel_midi_control returns 0 on allocation failure of new channel, otherwise 1)
+TSFDEF int tsf_channel_midi_control(tsf* f, int channel, int controller, int control_value);
+
+// Get current values set on the channels
+TSFDEF int tsf_channel_get_preset_index(tsf* f, int channel);
+TSFDEF int tsf_channel_get_preset_bank(tsf* f, int channel);
+TSFDEF int tsf_channel_get_preset_number(tsf* f, int channel);
+TSFDEF float tsf_channel_get_pan(tsf* f, int channel);
+TSFDEF float tsf_channel_get_volume(tsf* f, int channel);
+TSFDEF int tsf_channel_get_pitchwheel(tsf* f, int channel);
+TSFDEF float tsf_channel_get_pitchrange(tsf* f, int channel);
+TSFDEF float tsf_channel_get_tuning(tsf* f, int channel);
+
+#ifdef __cplusplus
+#  undef CPP_DEFAULT0
+}
+#endif
+
+// end header
+// ---------------------------------------------------------------------------------------------------------
+#endif //TSF_INCLUDE_TSF_INL
+
+#ifdef TSF_IMPLEMENTATION
+#undef TSF_IMPLEMENTATION
+
+// The lower this block size is the more accurate the effects are.
+// Increasing the value significantly lowers the CPU usage of the voice rendering.
+// If LFO affects the low-pass filter it can be hearable even as low as 8.
+#ifndef TSF_RENDER_EFFECTSAMPLEBLOCK
+#define TSF_RENDER_EFFECTSAMPLEBLOCK 64
+#endif
+
+// When using tsf_render_short, to do the conversion a buffer of a fixed size is
+// allocated on the stack. On low memory platforms this could be made smaller.
+// Increasing this above 512 should not have a significant impact on performance.
+// The value should be a multiple of TSF_RENDER_EFFECTSAMPLEBLOCK.
+#ifndef TSF_RENDER_SHORTBUFFERBLOCK
+#define TSF_RENDER_SHORTBUFFERBLOCK 512
+#endif
+
+// Grace release time for quick voice off (avoid clicking noise)
+#define TSF_FASTRELEASETIME 0.01f
+
+#if !defined(TSF_MALLOC) || !defined(TSF_FREE) || !defined(TSF_REALLOC)
+#  include <stdlib.h>
+#  define TSF_MALLOC  malloc
+#  define TSF_FREE    free
+#  define TSF_REALLOC realloc
+#endif
+
+#if !defined(TSF_MEMCPY) || !defined(TSF_MEMSET)
+#  include <string.h>
+#  define TSF_MEMCPY  memcpy
+#  define TSF_MEMSET  memset
+#endif
+
+#if !defined(TSF_POW) || !defined(TSF_POWF) || !defined(TSF_EXPF) || !defined(TSF_LOG) || !defined(TSF_TAN) || !defined(TSF_LOG10) || !defined(TSF_SQRT)
+#  include <math.h>
+#  if !defined(__cplusplus) && !defined(NAN) && !defined(powf) && !defined(expf) && !defined(sqrtf)
+#    define powf (float)pow // deal with old math.h
+#    define expf (float)exp // files that come without
+#    define sqrtf (float)sqrt // powf, expf and sqrtf
+#  endif
+#  define TSF_POW     pow
+#  define TSF_POWF    powf
+#  define TSF_EXPF    expf
+#  define TSF_LOG     log
+#  define TSF_TAN     tan
+#  define TSF_LOG10   log10
+#  define TSF_SQRTF   sqrtf
+#endif
+
+#ifndef TSF_NO_STDIO
+#  include <stdio.h>
+#endif
+
+#define TSF_TRUE 1
+#define TSF_FALSE 0
+#define TSF_BOOL unsigned char
+#define TSF_PI 3.14159265358979323846264338327950288
+#define TSF_NULL 0
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef char tsf_fourcc[4];
+typedef signed char tsf_s8;
+typedef unsigned char tsf_u8;
+typedef unsigned short tsf_u16;
+typedef signed short tsf_s16;
+typedef unsigned int tsf_u32;
+typedef char tsf_char20[20];
+
+#define TSF_FourCCEquals(value1, value2) (value1[0] == value2[0] && value1[1] == value2[1] && value1[2] == value2[2] && value1[3] == value2[3])
+
+struct tsf
+{
+	struct tsf_preset* presets;
+	float* fontSamples;
+	struct tsf_voice* voices;
+	struct tsf_channels* channels;
+
+	int presetNum;
+	int voiceNum;
+	int maxVoiceNum;
+	unsigned int voicePlayIndex;
+
+	enum TSFOutputMode outputmode;
+	float outSampleRate;
+	float globalGainDB;
+	int* refCount;
+};
+
+#ifndef TSF_NO_STDIO
+static int tsf_stream_stdio_read(FILE* f, void* ptr, unsigned int size) { return (int)fread(ptr, 1, size, f); }
+static int tsf_stream_stdio_skip(FILE* f, unsigned int count) { return !fseek(f, count, SEEK_CUR); }
+TSFDEF tsf* tsf_load_filename(const char* filename)
+{
+	tsf* res;
+	struct tsf_stream stream = { TSF_NULL, (int(*)(void*,void*,unsigned int))&tsf_stream_stdio_read, (int(*)(void*,unsigned int))&tsf_stream_stdio_skip };
+	#if __STDC_WANT_SECURE_LIB__
+	FILE* f = TSF_NULL; fopen_s(&f, filename, "rb");
+	#else
+	FILE* f = fopen(filename, "rb");
+	#endif
+	if (!f)
+	{
+		//if (e) *e = TSF_FILENOTFOUND;
+		return TSF_NULL;
+	}
+	stream.data = f;
+	res = tsf_load(&stream);
+	fclose(f);
+	return res;
+}
+#endif
+
+struct tsf_stream_memory { const char* buffer; unsigned int total, pos; };
+static int tsf_stream_memory_read(struct tsf_stream_memory* m, void* ptr, unsigned int size) { if (size > m->total - m->pos) size = m->total - m->pos; TSF_MEMCPY(ptr, m->buffer+m->pos, size); m->pos += size; return size; }
+static int tsf_stream_memory_skip(struct tsf_stream_memory* m, unsigned int count) { if (m->pos + count > m->total) return 0; m->pos += count; return 1; }
+TSFDEF tsf* tsf_load_memory(const void* buffer, int size)
+{
+	struct tsf_stream stream = { TSF_NULL, (int(*)(void*,void*,unsigned int))&tsf_stream_memory_read, (int(*)(void*,unsigned int))&tsf_stream_memory_skip };
+	struct tsf_stream_memory f = { 0, 0, 0 };
+	f.buffer = (const char*)buffer;
+	f.total = size;
+	stream.data = &f;
+	return tsf_load(&stream);
+}
+
+enum { TSF_LOOPMODE_NONE, TSF_LOOPMODE_CONTINUOUS, TSF_LOOPMODE_SUSTAIN };
+
+enum { TSF_SEGMENT_NONE, TSF_SEGMENT_DELAY, TSF_SEGMENT_ATTACK, TSF_SEGMENT_HOLD, TSF_SEGMENT_DECAY, TSF_SEGMENT_SUSTAIN, TSF_SEGMENT_RELEASE, TSF_SEGMENT_DONE };
+
+struct tsf_hydra
+{
+	struct tsf_hydra_phdr *phdrs; struct tsf_hydra_pbag *pbags; struct tsf_hydra_pmod *pmods;
+	struct tsf_hydra_pgen *pgens; struct tsf_hydra_inst *insts; struct tsf_hydra_ibag *ibags;
+	struct tsf_hydra_imod *imods; struct tsf_hydra_igen *igens; struct tsf_hydra_shdr *shdrs;
+	int phdrNum, pbagNum, pmodNum, pgenNum, instNum, ibagNum, imodNum, igenNum, shdrNum;
+};
+
+union tsf_hydra_genamount { struct { tsf_u8 lo, hi; } range; tsf_s16 shortAmount; tsf_u16 wordAmount; };
+struct tsf_hydra_phdr { tsf_char20 presetName; tsf_u16 preset, bank, presetBagNdx; tsf_u32 library, genre, morphology; };
+struct tsf_hydra_pbag { tsf_u16 genNdx, modNdx; };
+struct tsf_hydra_pmod { tsf_u16 modSrcOper, modDestOper; tsf_s16 modAmount; tsf_u16 modAmtSrcOper, modTransOper; };
+struct tsf_hydra_pgen { tsf_u16 genOper; union tsf_hydra_genamount genAmount; };
+struct tsf_hydra_inst { tsf_char20 instName; tsf_u16 instBagNdx; };
+struct tsf_hydra_ibag { tsf_u16 instGenNdx, instModNdx; };
+struct tsf_hydra_imod { tsf_u16 modSrcOper, modDestOper; tsf_s16 modAmount; tsf_u16 modAmtSrcOper, modTransOper; };
+struct tsf_hydra_igen { tsf_u16 genOper; union tsf_hydra_genamount genAmount; };
+struct tsf_hydra_shdr { tsf_char20 sampleName; tsf_u32 start, end, startLoop, endLoop, sampleRate; tsf_u8 originalPitch; tsf_s8 pitchCorrection; tsf_u16 sampleLink, sampleType; };
+
+#define TSFR(FIELD) stream->read(stream->data, &i->FIELD, sizeof(i->FIELD));
+static void tsf_hydra_read_phdr(struct tsf_hydra_phdr* i, struct tsf_stream* stream) { TSFR(presetName) TSFR(preset) TSFR(bank) TSFR(presetBagNdx) TSFR(library) TSFR(genre) TSFR(morphology) }
+static void tsf_hydra_read_pbag(struct tsf_hydra_pbag* i, struct tsf_stream* stream) { TSFR(genNdx) TSFR(modNdx) }
+static void tsf_hydra_read_pmod(struct tsf_hydra_pmod* i, struct tsf_stream* stream) { TSFR(modSrcOper) TSFR(modDestOper) TSFR(modAmount) TSFR(modAmtSrcOper) TSFR(modTransOper) }
+static void tsf_hydra_read_pgen(struct tsf_hydra_pgen* i, struct tsf_stream* stream) { TSFR(genOper) TSFR(genAmount) }
+static void tsf_hydra_read_inst(struct tsf_hydra_inst* i, struct tsf_stream* stream) { TSFR(instName) TSFR(instBagNdx) }
+static void tsf_hydra_read_ibag(struct tsf_hydra_ibag* i, struct tsf_stream* stream) { TSFR(instGenNdx) TSFR(instModNdx) }
+static void tsf_hydra_read_imod(struct tsf_hydra_imod* i, struct tsf_stream* stream) { TSFR(modSrcOper) TSFR(modDestOper) TSFR(modAmount) TSFR(modAmtSrcOper) TSFR(modTransOper) }
+static void tsf_hydra_read_igen(struct tsf_hydra_igen* i, struct tsf_stream* stream) { TSFR(genOper) TSFR(genAmount) }
+static void tsf_hydra_read_shdr(struct tsf_hydra_shdr* i, struct tsf_stream* stream) { TSFR(sampleName) TSFR(start) TSFR(end) TSFR(startLoop) TSFR(endLoop) TSFR(sampleRate) TSFR(originalPitch) TSFR(pitchCorrection) TSFR(sampleLink) TSFR(sampleType) }
+#undef TSFR
+
+struct tsf_riffchunk { tsf_fourcc id; tsf_u32 size; };
+struct tsf_envelope { float delay, attack, hold, decay, sustain, release, keynumToHold, keynumToDecay; };
+struct tsf_voice_envelope { unsigned char segment, segmentIsExponential : 1, isAmpEnv : 1; short midiVelocity; float level, slope; int samplesUntilNextSegment; struct tsf_envelope parameters; };
+struct tsf_voice_lowpass { double QInv, a0, a1, b1, b2, z1, z2; TSF_BOOL active; };
+struct tsf_voice_lfo { int samplesUntil; float level, delta; };
+
+struct tsf_region
+{
+	int loop_mode;
+	unsigned int sample_rate;
+	unsigned char lokey, hikey, lovel, hivel;
+	unsigned int group, offset, end, loop_start, loop_end;
+	int transpose, tune, pitch_keycenter, pitch_keytrack;
+	float attenuation, pan;
+	struct tsf_envelope ampenv, modenv;
+	int initialFilterQ, initialFilterFc;
+	int modEnvToPitch, modEnvToFilterFc, modLfoToFilterFc, modLfoToVolume;
+	float delayModLFO;
+	int freqModLFO, modLfoToPitch;
+	float delayVibLFO;
+	int freqVibLFO, vibLfoToPitch;
+};
+
+struct tsf_preset
+{
+	tsf_char20 presetName;
+	tsf_u16 preset, bank;
+	struct tsf_region* regions;
+	int regionNum;
+};
+
+struct tsf_voice
+{
+	int playingPreset, playingKey, playingChannel, heldSustain;
+	struct tsf_region* region;
+	double pitchInputTimecents, pitchOutputFactor;
+	double sourceSamplePosition;
+	float  noteGainDB, panFactorLeft, panFactorRight;
+	unsigned int playIndex, loopStart, loopEnd;
+	struct tsf_voice_envelope ampenv, modenv;
+	struct tsf_voice_lowpass lowpass;
+	struct tsf_voice_lfo modlfo, viblfo;
+};
+
+struct tsf_channel
+{
+	unsigned short presetIndex, bank, pitchWheel, midiPan, midiVolume, midiExpression, midiRPN, midiData : 14, sustain : 1;
+	float panOffset, gainDB, pitchRange, tuning;
+};
+
+struct tsf_channels
+{
+	void (*setupVoice)(tsf* f, struct tsf_voice* voice);
+	int channelNum, activeChannel;
+	struct tsf_channel channels[1];
+};
+
+static double tsf_timecents2Secsd(double timecents) { return TSF_POW(2.0, timecents / 1200.0); }
+static float tsf_timecents2Secsf(float timecents) { return TSF_POWF(2.0f, timecents / 1200.0f); }
+static float tsf_cents2Hertz(float cents) { return 8.176f * TSF_POWF(2.0f, cents / 1200.0f); }
+static float tsf_decibelsToGain(float db) { return (db > -100.f ? TSF_POWF(10.0f, db * 0.05f) : 0); }
+static float tsf_gainToDecibels(float gain) { return (gain <= .00001f ? -100.f : (float)(20.0 * TSF_LOG10(gain))); }
+
+static TSF_BOOL tsf_riffchunk_read(struct tsf_riffchunk* parent, struct tsf_riffchunk* chunk, struct tsf_stream* stream)
+{
+	TSF_BOOL IsRiff, IsList;
+	if (parent && sizeof(tsf_fourcc) + sizeof(tsf_u32) > parent->size) return TSF_FALSE;
+	if (!stream->read(stream->data, &chunk->id, sizeof(tsf_fourcc)) || *chunk->id <= ' ' || *chunk->id >= 'z') return TSF_FALSE;
+	if (!stream->read(stream->data, &chunk->size, sizeof(tsf_u32))) return TSF_FALSE;
+	if (parent && sizeof(tsf_fourcc) + sizeof(tsf_u32) + chunk->size > parent->size) return TSF_FALSE;
+	if (parent) parent->size -= sizeof(tsf_fourcc) + sizeof(tsf_u32) + chunk->size;
+	IsRiff = TSF_FourCCEquals(chunk->id, "RIFF"), IsList = TSF_FourCCEquals(chunk->id, "LIST");
+	if (IsRiff && parent) return TSF_FALSE; //not allowed
+	if (!IsRiff && !IsList) return TSF_TRUE; //custom type without sub type
+	if (!stream->read(stream->data, &chunk->id, sizeof(tsf_fourcc)) || *chunk->id <= ' ' || *chunk->id >= 'z') return TSF_FALSE;
+	chunk->size -= sizeof(tsf_fourcc);
+	return TSF_TRUE;
+}
+
+static void tsf_region_clear(struct tsf_region* i, TSF_BOOL for_relative)
+{
+	TSF_MEMSET(i, 0, sizeof(struct tsf_region));
+	i->hikey = i->hivel = 127;
+	i->pitch_keycenter = 60; // C4
+	if (for_relative) return;
+
+	i->pitch_keytrack = 100;
+
+	i->pitch_keycenter = -1;
+
+	// SF2 defaults in timecents.
+	i->ampenv.delay = i->ampenv.attack = i->ampenv.hold = i->ampenv.decay = i->ampenv.release = -12000.0f;
+	i->modenv.delay = i->modenv.attack = i->modenv.hold = i->modenv.decay = i->modenv.release = -12000.0f;
+
+	i->initialFilterFc = 13500;
+
+	i->delayModLFO = -12000.0f;
+	i->delayVibLFO = -12000.0f;
+}
+
+static void tsf_region_operator(struct tsf_region* region, tsf_u16 genOper, union tsf_hydra_genamount* amount, struct tsf_region* merge_region)
+{
+	enum
+	{
+		_GEN_TYPE_MASK       = 0x0F,
+		GEN_FLOAT            = 0x01,
+		GEN_INT              = 0x02,
+		GEN_UINT_ADD         = 0x03,
+		GEN_UINT_ADD15       = 0x04,
+		GEN_KEYRANGE         = 0x05,
+		GEN_VELRANGE         = 0x06,
+		GEN_LOOPMODE         = 0x07,
+		GEN_GROUP            = 0x08,
+		GEN_KEYCENTER        = 0x09,
+
+		_GEN_LIMIT_MASK      = 0xF0,
+		GEN_INT_LIMIT12K     = 0x10, //min -12000, max 12000
+		GEN_INT_LIMITFC      = 0x20, //min 1500, max 13500
+		GEN_INT_LIMITQ       = 0x30, //min 0, max 960
+		GEN_INT_LIMIT960     = 0x40, //min -960, max 960
+		GEN_INT_LIMIT16K4500 = 0x50, //min -16000, max 4500
+		GEN_FLOAT_LIMIT12K5K = 0x60, //min -12000, max 5000
+		GEN_FLOAT_LIMIT12K8K = 0x70, //min -12000, max 8000
+		GEN_FLOAT_LIMIT1200  = 0x80, //min -1200, max 1200
+		GEN_FLOAT_LIMITPAN   = 0x90, //* .001f, min -.5f, max .5f,
+		GEN_FLOAT_LIMITATTN  = 0xA0, //* .1f, min 0, max 144.0
+		GEN_FLOAT_MAX1000    = 0xB0, //min 0, max 1000
+		GEN_FLOAT_MAX1440    = 0xC0, //min 0, max 1440
+
+		_GEN_MAX = 59
+	};
+	#define _TSFREGIONOFFSET(TYPE, FIELD) (unsigned char)(((TYPE*)&((struct tsf_region*)0)->FIELD) - (TYPE*)0)
+	#define _TSFREGIONENVOFFSET(TYPE, ENV, FIELD) (unsigned char)(((TYPE*)&((&(((struct tsf_region*)0)->ENV))->FIELD)) - (TYPE*)0)
+	static const struct { unsigned char mode, offset; } genMetas[_GEN_MAX] =
+	{
+		{ GEN_UINT_ADD                     , _TSFREGIONOFFSET(unsigned int, offset               ) }, // 0 StartAddrsOffset
+		{ GEN_UINT_ADD                     , _TSFREGIONOFFSET(unsigned int, end                  ) }, // 1 EndAddrsOffset
+		{ GEN_UINT_ADD                     , _TSFREGIONOFFSET(unsigned int, loop_start           ) }, // 2 StartloopAddrsOffset
+		{ GEN_UINT_ADD                     , _TSFREGIONOFFSET(unsigned int, loop_end             ) }, // 3 EndloopAddrsOffset
+		{ GEN_UINT_ADD15                   , _TSFREGIONOFFSET(unsigned int, offset               ) }, // 4 StartAddrsCoarseOffset
+		{ GEN_INT   | GEN_INT_LIMIT12K     , _TSFREGIONOFFSET(         int, modLfoToPitch        ) }, // 5 ModLfoToPitch
+		{ GEN_INT   | GEN_INT_LIMIT12K     , _TSFREGIONOFFSET(         int, vibLfoToPitch        ) }, // 6 VibLfoToPitch
+		{ GEN_INT   | GEN_INT_LIMIT12K     , _TSFREGIONOFFSET(         int, modEnvToPitch        ) }, // 7 ModEnvToPitch
+		{ GEN_INT   | GEN_INT_LIMITFC      , _TSFREGIONOFFSET(         int, initialFilterFc      ) }, // 8 InitialFilterFc
+		{ GEN_INT   | GEN_INT_LIMITQ       , _TSFREGIONOFFSET(         int, initialFilterQ       ) }, // 9 InitialFilterQ
+		{ GEN_INT   | GEN_INT_LIMIT12K     , _TSFREGIONOFFSET(         int, modLfoToFilterFc     ) }, //10 ModLfoToFilterFc
+		{ GEN_INT   | GEN_INT_LIMIT12K     , _TSFREGIONOFFSET(         int, modEnvToFilterFc     ) }, //11 ModEnvToFilterFc
+		{ GEN_UINT_ADD15                   , _TSFREGIONOFFSET(unsigned int, end                  ) }, //12 EndAddrsCoarseOffset
+		{ GEN_INT   | GEN_INT_LIMIT960     , _TSFREGIONOFFSET(         int, modLfoToVolume       ) }, //13 ModLfoToVolume
+		{ 0                                , (0                                                  ) }, //   Unused
+		{ 0                                , (0                                                  ) }, //15 ChorusEffectsSend (unsupported)
+		{ 0                                , (0                                                  ) }, //16 ReverbEffectsSend (unsupported)
+		{ GEN_FLOAT | GEN_FLOAT_LIMITPAN   , _TSFREGIONOFFSET(       float, pan                  ) }, //17 Pan
+		{ 0                                , (0                                                  ) }, //   Unused
+		{ 0                                , (0                                                  ) }, //   Unused
+		{ 0                                , (0                                                  ) }, //   Unused
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K5K , _TSFREGIONOFFSET(       float, delayModLFO          ) }, //21 DelayModLFO
+		{ GEN_INT   | GEN_INT_LIMIT16K4500 , _TSFREGIONOFFSET(         int, freqModLFO           ) }, //22 FreqModLFO
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K5K , _TSFREGIONOFFSET(       float, delayVibLFO          ) }, //23 DelayVibLFO
+		{ GEN_INT   | GEN_INT_LIMIT16K4500 , _TSFREGIONOFFSET(         int, freqVibLFO           ) }, //24 FreqVibLFO
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K5K , _TSFREGIONENVOFFSET(    float, modenv, delay        ) }, //25 DelayModEnv
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K8K , _TSFREGIONENVOFFSET(    float, modenv, attack       ) }, //26 AttackModEnv
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K5K , _TSFREGIONENVOFFSET(    float, modenv, hold         ) }, //27 HoldModEnv
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K8K , _TSFREGIONENVOFFSET(    float, modenv, decay        ) }, //28 DecayModEnv
+		{ GEN_FLOAT | GEN_FLOAT_MAX1000    , _TSFREGIONENVOFFSET(    float, modenv, sustain      ) }, //29 SustainModEnv
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K8K , _TSFREGIONENVOFFSET(    float, modenv, release      ) }, //30 ReleaseModEnv
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT1200  , _TSFREGIONENVOFFSET(    float, modenv, keynumToHold ) }, //31 KeynumToModEnvHold
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT1200  , _TSFREGIONENVOFFSET(    float, modenv, keynumToDecay) }, //32 KeynumToModEnvDecay
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K5K , _TSFREGIONENVOFFSET(    float, ampenv, delay        ) }, //33 DelayVolEnv
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K8K , _TSFREGIONENVOFFSET(    float, ampenv, attack       ) }, //34 AttackVolEnv
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K5K , _TSFREGIONENVOFFSET(    float, ampenv, hold         ) }, //35 HoldVolEnv
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K8K , _TSFREGIONENVOFFSET(    float, ampenv, decay        ) }, //36 DecayVolEnv
+		{ GEN_FLOAT | GEN_FLOAT_MAX1440    , _TSFREGIONENVOFFSET(    float, ampenv, sustain      ) }, //37 SustainVolEnv
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT12K8K , _TSFREGIONENVOFFSET(    float, ampenv, release      ) }, //38 ReleaseVolEnv
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT1200  , _TSFREGIONENVOFFSET(    float, ampenv, keynumToHold ) }, //39 KeynumToVolEnvHold
+		{ GEN_FLOAT | GEN_FLOAT_LIMIT1200  , _TSFREGIONENVOFFSET(    float, ampenv, keynumToDecay) }, //40 KeynumToVolEnvDecay
+		{ 0                                , (0                                                  ) }, //   Instrument (special)
+		{ 0                                , (0                                                  ) }, //   Reserved
+		{ GEN_KEYRANGE                     , (0                                                  ) }, //43 KeyRange
+		{ GEN_VELRANGE                     , (0                                                  ) }, //44 VelRange
+		{ GEN_UINT_ADD15                   , _TSFREGIONOFFSET(unsigned int, loop_start           ) }, //45 StartloopAddrsCoarseOffset
+		{ 0                                , (0                                                  ) }, //46 Keynum (special)
+		{ 0                                , (0                                                  ) }, //47 Velocity (special)
+		{ GEN_FLOAT | GEN_FLOAT_LIMITATTN  , _TSFREGIONOFFSET(       float, attenuation          ) }, //48 InitialAttenuation
+		{ 0                                , (0                                                  ) }, //   Reserved
+		{ GEN_UINT_ADD15                   , _TSFREGIONOFFSET(unsigned int, loop_end             ) }, //50 EndloopAddrsCoarseOffset
+		{ GEN_INT                          , _TSFREGIONOFFSET(         int, transpose            ) }, //51 CoarseTune
+		{ GEN_INT                          , _TSFREGIONOFFSET(         int, tune                 ) }, //52 FineTune
+		{ 0                                , (0                                                  ) }, //   SampleID (special)
+		{ GEN_LOOPMODE                     , _TSFREGIONOFFSET(         int, loop_mode            ) }, //54 SampleModes
+		{ 0                                , (0                                                  ) }, //   Reserved
+		{ GEN_INT                          , _TSFREGIONOFFSET(         int, pitch_keytrack       ) }, //56 ScaleTuning
+		{ GEN_GROUP                        , _TSFREGIONOFFSET(unsigned int, group                ) }, //57 ExclusiveClass
+		{ GEN_KEYCENTER                    , _TSFREGIONOFFSET(         int, pitch_keycenter      ) }, //58 OverridingRootKey
+	};
+	#undef _TSFREGIONOFFSET
+	#undef _TSFREGIONENVOFFSET
+	if (amount)
+	{
+		int offset;
+		if (genOper >= _GEN_MAX) return;
+		offset = genMetas[genOper].offset;
+		switch (genMetas[genOper].mode & _GEN_TYPE_MASK)
+		{
+			case GEN_FLOAT:      ((       float*)region)[offset]  = amount->shortAmount;     return;
+			case GEN_INT:        ((         int*)region)[offset]  = amount->shortAmount;     return;
+			case GEN_UINT_ADD:   ((unsigned int*)region)[offset] += amount->shortAmount;     return;
+			case GEN_UINT_ADD15: ((unsigned int*)region)[offset] += amount->shortAmount<<15; return;
+			case GEN_KEYRANGE:   region->lokey = amount->range.lo; region->hikey = amount->range.hi; return;
+			case GEN_VELRANGE:   region->lovel = amount->range.lo; region->hivel = amount->range.hi; return;
+			case GEN_LOOPMODE:   region->loop_mode       = ((amount->wordAmount&3) == 3 ? TSF_LOOPMODE_SUSTAIN : ((amount->wordAmount&3) == 1 ? TSF_LOOPMODE_CONTINUOUS : TSF_LOOPMODE_NONE)); return;
+			case GEN_GROUP:      region->group           = amount->wordAmount;  return;
+			case GEN_KEYCENTER:  region->pitch_keycenter = amount->shortAmount; return;
+		}
+	}
+	else //merge regions and clamp values
+	{
+		for (genOper = 0; genOper != _GEN_MAX; genOper++)
+		{
+			int offset = genMetas[genOper].offset;
+			switch (genMetas[genOper].mode & _GEN_TYPE_MASK)
+			{
+				case GEN_FLOAT:
+				{
+					float *val = &((float*)region)[offset], vfactor, vmin, vmax;
+					*val += ((float*)merge_region)[offset];
+					switch (genMetas[genOper].mode & _GEN_LIMIT_MASK)
+					{
+						case GEN_FLOAT_LIMIT12K5K: vfactor =   1.0f; vmin = -12000.0f; vmax = 5000.0f; break;
+						case GEN_FLOAT_LIMIT12K8K: vfactor =   1.0f; vmin = -12000.0f; vmax = 8000.0f; break;
+						case GEN_FLOAT_LIMIT1200:  vfactor =   1.0f; vmin =  -1200.0f; vmax = 1200.0f; break;
+						case GEN_FLOAT_LIMITPAN:   vfactor = 0.001f; vmin =     -0.5f; vmax =    0.5f; break;
+						case GEN_FLOAT_LIMITATTN:  vfactor =  0.01f; vmin =      0.0f; vmax =   14.4f; break;
+						case GEN_FLOAT_MAX1000:    vfactor =   1.0f; vmin =      0.0f; vmax = 1000.0f; break;
+						case GEN_FLOAT_MAX1440:    vfactor =   1.0f; vmin =      0.0f; vmax = 1440.0f; break;
+						default: continue;
+					}
+					*val *= vfactor;
+					if      (*val < vmin) *val = vmin;
+					else if (*val > vmax) *val = vmax;
+					continue;
+				}
+				case GEN_INT:
+				{
+					int *val = &((int*)region)[offset], vmin, vmax;
+					*val += ((int*)merge_region)[offset];
+					switch (genMetas[genOper].mode & _GEN_LIMIT_MASK)
+					{
+						case GEN_INT_LIMIT12K:     vmin = -12000; vmax = 12000; break;
+						case GEN_INT_LIMITFC:      vmin =   1500; vmax = 13500; break;
+						case GEN_INT_LIMITQ:       vmin =      0; vmax =   960; break;
+						case GEN_INT_LIMIT960:     vmin =   -960; vmax =   960; break;
+						case GEN_INT_LIMIT16K4500: vmin = -16000; vmax =  4500; break;
+						default: continue;
+					}
+					if      (*val < vmin) *val = vmin;
+					else if (*val > vmax) *val = vmax;
+					continue;
+				}
+				case GEN_UINT_ADD:
+				{
+					((unsigned int*)region)[offset] += ((unsigned int*)merge_region)[offset];
+					continue;
+				}
+			}
+		}
+	}
+}
+
+static void tsf_region_envtosecs(struct tsf_envelope* p, TSF_BOOL sustainIsGain)
+{
+	// EG times need to be converted from timecents to seconds.
+	// Pin very short EG segments.  Timecents don't get to zero, and our EG is
+	// happier with zero values.
+	p->delay   = (p->delay   < -11950.0f ? 0.0f : tsf_timecents2Secsf(p->delay));
+	p->attack  = (p->attack  < -11950.0f ? 0.0f : tsf_timecents2Secsf(p->attack));
+	p->release = (p->release < -11950.0f ? 0.0f : tsf_timecents2Secsf(p->release));
+
+	// If we have dynamic hold or decay times depending on key number we need
+	// to keep the values in timecents so we can calculate it during startNote
+	if (!p->keynumToHold)  p->hold  = (p->hold  < -11950.0f ? 0.0f : tsf_timecents2Secsf(p->hold));
+	if (!p->keynumToDecay) p->decay = (p->decay < -11950.0f ? 0.0f : tsf_timecents2Secsf(p->decay));
+
+	if (p->sustain < 0.0f) p->sustain = 0.0f;
+	else if (sustainIsGain) p->sustain = tsf_decibelsToGain(-p->sustain / 10.0f);
+	else p->sustain = 1.0f - (p->sustain / 1000.0f);
+}
+
+static int tsf_load_presets(tsf* res, struct tsf_hydra *hydra, unsigned int fontSampleCount)
+{
+	enum { GenInstrument = 41, GenKeyRange = 43, GenVelRange = 44, GenSampleID = 53 };
+	// Read each preset.
+	struct tsf_hydra_phdr *pphdr, *pphdrMax;
+	res->presetNum = hydra->phdrNum - 1;
+	res->presets = (struct tsf_preset*)TSF_MALLOC(res->presetNum * sizeof(struct tsf_preset));
+	if (!res->presets) return 0;
+	else { int i; for (i = 0; i != res->presetNum; i++) res->presets[i].regions = TSF_NULL; }
+	for (pphdr = hydra->phdrs, pphdrMax = pphdr + hydra->phdrNum - 1; pphdr != pphdrMax; pphdr++)
+	{
+		int sortedIndex = 0, region_index = 0;
+		struct tsf_hydra_phdr *otherphdr;
+		struct tsf_preset* preset;
+		struct tsf_hydra_pbag *ppbag, *ppbagEnd;
+		struct tsf_region globalRegion;
+		for (otherphdr = hydra->phdrs; otherphdr != pphdrMax; otherphdr++)
+		{
+			if (otherphdr == pphdr || otherphdr->bank > pphdr->bank) continue;
+			else if (otherphdr->bank < pphdr->bank) sortedIndex++;
+			else if (otherphdr->preset > pphdr->preset) continue;
+			else if (otherphdr->preset < pphdr->preset) sortedIndex++;
+			else if (otherphdr < pphdr) sortedIndex++;
+		}
+
+		preset = &res->presets[sortedIndex];
+		TSF_MEMCPY(preset->presetName, pphdr->presetName, sizeof(preset->presetName));
+		preset->presetName[sizeof(preset->presetName)-1] = '\0'; //should be zero terminated in source file but make sure
+		preset->bank = pphdr->bank;
+		preset->preset = pphdr->preset;
+		preset->regionNum = 0;
+
+		//count regions covered by this preset
+		for (ppbag = hydra->pbags + pphdr->presetBagNdx, ppbagEnd = hydra->pbags + pphdr[1].presetBagNdx; ppbag != ppbagEnd; ppbag++)
+		{
+			unsigned char plokey = 0, phikey = 127, plovel = 0, phivel = 127;
+			struct tsf_hydra_pgen *ppgen, *ppgenEnd; struct tsf_hydra_inst *pinst; struct tsf_hydra_ibag *pibag, *pibagEnd; struct tsf_hydra_igen *pigen, *pigenEnd;
+			for (ppgen = hydra->pgens + ppbag->genNdx, ppgenEnd = hydra->pgens + ppbag[1].genNdx; ppgen != ppgenEnd; ppgen++)
+			{
+				if (ppgen->genOper == GenKeyRange) { plokey = ppgen->genAmount.range.lo; phikey = ppgen->genAmount.range.hi; continue; }
+				if (ppgen->genOper == GenVelRange) { plovel = ppgen->genAmount.range.lo; phivel = ppgen->genAmount.range.hi; continue; }
+				if (ppgen->genOper != GenInstrument) continue;
+				if (ppgen->genAmount.wordAmount >= hydra->instNum) continue;
+				pinst = hydra->insts + ppgen->genAmount.wordAmount;
+				for (pibag = hydra->ibags + pinst->instBagNdx, pibagEnd = hydra->ibags + pinst[1].instBagNdx; pibag != pibagEnd; pibag++)
+				{
+					unsigned char ilokey = 0, ihikey = 127, ilovel = 0, ihivel = 127;
+					for (pigen = hydra->igens + pibag->instGenNdx, pigenEnd = hydra->igens + pibag[1].instGenNdx; pigen != pigenEnd; pigen++)
+					{
+						if (pigen->genOper == GenKeyRange) { ilokey = pigen->genAmount.range.lo; ihikey = pigen->genAmount.range.hi; continue; }
+						if (pigen->genOper == GenVelRange) { ilovel = pigen->genAmount.range.lo; ihivel = pigen->genAmount.range.hi; continue; }
+						if (pigen->genOper == GenSampleID && ihikey >= plokey && ilokey <= phikey && ihivel >= plovel && ilovel <= phivel) preset->regionNum++;
+					}
+				}
+			}
+		}
+
+		preset->regions = (struct tsf_region*)TSF_MALLOC(preset->regionNum * sizeof(struct tsf_region));
+		if (!preset->regions)
+		{
+			int i; for (i = 0; i != res->presetNum; i++) TSF_FREE(res->presets[i].regions);
+			TSF_FREE(res->presets);
+			return 0;
+		}
+		tsf_region_clear(&globalRegion, TSF_TRUE);
+
+		// Zones.
+		for (ppbag = hydra->pbags + pphdr->presetBagNdx, ppbagEnd = hydra->pbags + pphdr[1].presetBagNdx; ppbag != ppbagEnd; ppbag++)
+		{
+			struct tsf_hydra_pgen *ppgen, *ppgenEnd; struct tsf_hydra_inst *pinst; struct tsf_hydra_ibag *pibag, *pibagEnd; struct tsf_hydra_igen *pigen, *pigenEnd;
+			struct tsf_region presetRegion = globalRegion;
+			int hadGenInstrument = 0;
+
+			// Generators.
+			for (ppgen = hydra->pgens + ppbag->genNdx, ppgenEnd = hydra->pgens + ppbag[1].genNdx; ppgen != ppgenEnd; ppgen++)
+			{
+				// Instrument.
+				if (ppgen->genOper == GenInstrument)
+				{
+					struct tsf_region instRegion;
+					tsf_u16 whichInst = ppgen->genAmount.wordAmount;
+					if (whichInst >= hydra->instNum) continue;
+
+					tsf_region_clear(&instRegion, TSF_FALSE);
+					pinst = &hydra->insts[whichInst];
+					for (pibag = hydra->ibags + pinst->instBagNdx, pibagEnd = hydra->ibags + pinst[1].instBagNdx; pibag != pibagEnd; pibag++)
+					{
+						// Generators.
+						struct tsf_region zoneRegion = instRegion;
+						int hadSampleID = 0;
+						for (pigen = hydra->igens + pibag->instGenNdx, pigenEnd = hydra->igens + pibag[1].instGenNdx; pigen != pigenEnd; pigen++)
+						{
+							if (pigen->genOper == GenSampleID)
+							{
+								struct tsf_hydra_shdr* pshdr;
+
+								//preset region key and vel ranges are a filter for the zone regions
+								if (zoneRegion.hikey < presetRegion.lokey || zoneRegion.lokey > presetRegion.hikey) continue;
+								if (zoneRegion.hivel < presetRegion.lovel || zoneRegion.lovel > presetRegion.hivel) continue;
+								if (presetRegion.lokey > zoneRegion.lokey) zoneRegion.lokey = presetRegion.lokey;
+								if (presetRegion.hikey < zoneRegion.hikey) zoneRegion.hikey = presetRegion.hikey;
+								if (presetRegion.lovel > zoneRegion.lovel) zoneRegion.lovel = presetRegion.lovel;
+								if (presetRegion.hivel < zoneRegion.hivel) zoneRegion.hivel = presetRegion.hivel;
+
+								//sum regions
+								tsf_region_operator(&zoneRegion, 0, TSF_NULL, &presetRegion);
+
+								// EG times need to be converted from timecents to seconds.
+								tsf_region_envtosecs(&zoneRegion.ampenv, TSF_TRUE);
+								tsf_region_envtosecs(&zoneRegion.modenv, TSF_FALSE);
+
+								// LFO times need to be converted from timecents to seconds.
+								zoneRegion.delayModLFO = (zoneRegion.delayModLFO < -11950.0f ? 0.0f : tsf_timecents2Secsf(zoneRegion.delayModLFO));
+								zoneRegion.delayVibLFO = (zoneRegion.delayVibLFO < -11950.0f ? 0.0f : tsf_timecents2Secsf(zoneRegion.delayVibLFO));
+
+								// Fixup sample positions
+								pshdr = &hydra->shdrs[pigen->genAmount.wordAmount];
+								zoneRegion.offset += pshdr->start;
+								zoneRegion.end += pshdr->end;
+								zoneRegion.loop_start += pshdr->startLoop;
+								zoneRegion.loop_end += pshdr->endLoop;
+								if (pshdr->endLoop > 0) zoneRegion.loop_end -= 1;
+								if (zoneRegion.loop_end > fontSampleCount) zoneRegion.loop_end = fontSampleCount;
+								if (zoneRegion.pitch_keycenter == -1) zoneRegion.pitch_keycenter = pshdr->originalPitch;
+								zoneRegion.tune += pshdr->pitchCorrection;
+								zoneRegion.sample_rate = pshdr->sampleRate;
+								if (zoneRegion.end && zoneRegion.end < fontSampleCount) zoneRegion.end++;
+								else zoneRegion.end = fontSampleCount;
+
+								preset->regions[region_index] = zoneRegion;
+								region_index++;
+								hadSampleID = 1;
+							}
+							else tsf_region_operator(&zoneRegion, pigen->genOper, &pigen->genAmount, TSF_NULL);
+						}
+
+						// Handle instrument's global zone.
+						if (pibag == hydra->ibags + pinst->instBagNdx && !hadSampleID)
+							instRegion = zoneRegion;
+
+						// Modulators (TODO)
+						//if (ibag->instModNdx < ibag[1].instModNdx) addUnsupportedOpcode("any modulator");
+					}
+					hadGenInstrument = 1;
+				}
+				else tsf_region_operator(&presetRegion, ppgen->genOper, &ppgen->genAmount, TSF_NULL);
+			}
+
+			// Modulators (TODO)
+			//if (pbag->modNdx < pbag[1].modNdx) addUnsupportedOpcode("any modulator");
+
+			// Handle preset's global zone.
+			if (ppbag == hydra->pbags + pphdr->presetBagNdx && !hadGenInstrument)
+				globalRegion = presetRegion;
+		}
+	}
+	return 1;
+}
+
+#ifdef STB_VORBIS_INCLUDE_STB_VORBIS_H
+static int tsf_decode_ogg(const tsf_u8 *pSmpl, const tsf_u8 *pSmplEnd, float** pRes, tsf_u32* pResNum, tsf_u32* pResMax, tsf_u32 resInitial)
+{
+	float *res = *pRes, *oldres; tsf_u32 resNum = *pResNum; tsf_u32 resMax = *pResMax; stb_vorbis *v;
+
+	// Use whatever stb_vorbis API that is available (either pull or push)
+	#if !defined(STB_VORBIS_NO_PULLDATA_API) && !defined(STB_VORBIS_NO_FROMMEMORY)
+	v = stb_vorbis_open_memory(pSmpl, (int)(pSmplEnd - pSmpl), TSF_NULL, TSF_NULL);
+	#else
+	{ int use, err; v = stb_vorbis_open_pushdata(pSmpl, (int)(pSmplEnd - pSmpl), &use, &err, TSF_NULL); pSmpl += use; }
+	#endif
+	if (v == TSF_NULL) return 0;
+
+	for (;;)
+	{
+		float** outputs; int n_samples;
+
+		// Decode one frame of vorbis samples with whatever stb_vorbis API that is available
+		#if !defined(STB_VORBIS_NO_PULLDATA_API) && !defined(STB_VORBIS_NO_FROMMEMORY)
+		n_samples = stb_vorbis_get_frame_float(v, TSF_NULL, &outputs);
+		if (!n_samples) break;
+		#else
+		if (pSmpl >= pSmplEnd) break;
+		{ int use = stb_vorbis_decode_frame_pushdata(v, pSmpl, (int)(pSmplEnd - pSmpl), TSF_NULL, &outputs, &n_samples); pSmpl += use; }
+		if (!n_samples) continue;
+		#endif
+
+		// Expand our output buffer if necessary then copy over the decoded frame samples
+		resNum += n_samples;
+		if (resNum > resMax)
+		{
+			do { resMax += (resMax ? (resMax < 1048576 ? resMax : 1048576) : resInitial); } while (resNum > resMax);
+			oldres = res;
+			res = (float*)TSF_REALLOC(res, resMax * sizeof(float));
+			if (!res) { TSF_FREE(oldres); stb_vorbis_close(v); return 0; }
+		}
+		TSF_MEMCPY(res + resNum - n_samples, outputs[0], n_samples * sizeof(float));
+	}
+	stb_vorbis_close(v);
+	*pRes = res; *pResNum = resNum; *pResMax = resMax;
+	return 1;
+}
+
+static int tsf_decode_sf3_samples(const void* rawBuffer, float** pFloatBuffer, unsigned int* pSmplCount, struct tsf_hydra *hydra)
+{
+	const tsf_u8* smplBuffer = (const tsf_u8*)rawBuffer;
+	tsf_u32 smplLength = *pSmplCount, resNum = 0, resMax = 0, resInitial = (smplLength > 0x100000 ? (smplLength & ~0xFFFFF) : 65536);
+	float *res = TSF_NULL, *oldres;
+	int i, shdrLast = hydra->shdrNum - 1, is_sf3 = 0;
+	for (i = 0; i <= shdrLast; i++)
+	{
+		struct tsf_hydra_shdr *shdr = &hydra->shdrs[i];
+		if (shdr->sampleType & 0x30) // compression flags (sometimes Vorbis flag)
+		{
+			const tsf_u8 *pSmpl = smplBuffer + shdr->start, *pSmplEnd = smplBuffer + shdr->end;
+			if (pSmpl + 4 > pSmplEnd || !TSF_FourCCEquals(pSmpl, "OggS"))
+			{
+				shdr->start = shdr->end = shdr->startLoop = shdr->endLoop = 0;
+				continue;
+			}
+
+			// Fix up sample indices in shdr (end index is set after decoding)
+			shdr->start = resNum;
+			shdr->startLoop += resNum;
+			shdr->endLoop += resNum;
+			if (!tsf_decode_ogg(pSmpl, pSmplEnd, &res, &resNum, &resMax, resInitial)) { TSF_FREE(res); return 0; }
+			shdr->end = resNum;
+			is_sf3 = 1;
+		}
+		else // raw PCM sample
+		{
+			float *out; short *in = (short*)smplBuffer + resNum, *inEnd; tsf_u32 oldResNum = resNum;
+			if (is_sf3) // Fix up sample indices in shdr
+			{
+				tsf_u32 fix_offset = resNum - shdr->start;
+				in -= fix_offset;
+				shdr->start = resNum;
+				shdr->end += fix_offset;
+				shdr->startLoop += fix_offset;
+				shdr->endLoop += fix_offset;
+			}
+			inEnd = in + ((shdr->end >= shdr->endLoop ? shdr->end : shdr->endLoop) - resNum);
+			if (i == shdrLast || (tsf_u8*)inEnd > (smplBuffer + smplLength)) inEnd = (short*)(smplBuffer + smplLength);
+			if (inEnd <= in) continue;
+
+			// expand our output buffer if necessary then convert the PCM data from short to float
+			resNum += (tsf_u32)(inEnd - in);
+			if (resNum > resMax)
+			{
+				do { resMax += (resMax ? (resMax < 1048576 ? resMax : 1048576) : resInitial); } while (resNum > resMax);
+				oldres = res;
+				res = (float*)TSF_REALLOC(res, resMax * sizeof(float));
+				if (!res) { TSF_FREE(oldres); return 0; }
+			}
+
+			// Convert the samples from short to float
+			for (out = res + oldResNum; in < inEnd;)
+				*(out++) = (float)(*(in++) / 32767.0);
+		}
+	}
+
+	// Trim the sample buffer down then return success (unless out of memory)
+	if (!(*pFloatBuffer = (float*)TSF_REALLOC(res, resNum * sizeof(float)))) *pFloatBuffer = res;
+	*pSmplCount = resNum;
+	return (res ? 1 : 0);
+}
+#endif
+
+static int tsf_load_samples(void** pRawBuffer, float** pFloatBuffer, unsigned int* pSmplCount, struct tsf_riffchunk *chunkSmpl, struct tsf_stream* stream)
+{
+	#ifdef STB_VORBIS_INCLUDE_STB_VORBIS_H
+	// With OGG Vorbis support we cannot pre-allocate the memory for tsf_decode_sf3_samples
+	tsf_u32 resNum, resMax; float* oldres;
+	*pSmplCount = chunkSmpl->size;
+	*pRawBuffer = (void*)TSF_MALLOC(*pSmplCount);
+	if (!*pRawBuffer || !stream->read(stream->data, *pRawBuffer, chunkSmpl->size)) return 0;
+	if (chunkSmpl->id[3] != 'o') return 1;
+
+	// Decode custom .sfo 'smpo' format where all samples are in a single ogg stream
+	resNum = resMax = 0;
+	if (!tsf_decode_ogg((tsf_u8*)*pRawBuffer, (tsf_u8*)*pRawBuffer + chunkSmpl->size, pFloatBuffer, &resNum, &resMax, 65536)) return 0;
+	oldres = *pFloatBuffer;
+	if (!(*pFloatBuffer = (float*)TSF_REALLOC(*pFloatBuffer, resNum * sizeof(float)))) *pFloatBuffer = oldres;
+	*pSmplCount = resNum;
+	return (*pFloatBuffer ? 1 : 0);
+	#else
+	// Inline convert the samples from short to float
+	float *res, *out; const short *in;
+	(void)pRawBuffer;
+	*pSmplCount = chunkSmpl->size / (unsigned int)sizeof(short);
+	*pFloatBuffer = (float*)TSF_MALLOC(*pSmplCount * sizeof(float));
+	if (!*pFloatBuffer || !stream->read(stream->data, *pFloatBuffer, chunkSmpl->size)) return 0;
+	for (res = *pFloatBuffer, out = res + *pSmplCount, in = (short*)res + *pSmplCount; out != res;)
+		*(--out) = (float)(*(--in) / 32767.0);
+	return 1;
+	#endif
+}
+
+static int tsf_voice_envelope_release_samples(struct tsf_voice_envelope* e, float outSampleRate)
+{
+	return (int)((e->parameters.release <= 0 ? TSF_FASTRELEASETIME : e->parameters.release) * outSampleRate);
+}
+
+static void tsf_voice_envelope_nextsegment(struct tsf_voice_envelope* e, short active_segment, float outSampleRate)
+{
+	switch (active_segment)
+	{
+		case TSF_SEGMENT_NONE:
+			e->samplesUntilNextSegment = (int)(e->parameters.delay * outSampleRate);
+			if (e->samplesUntilNextSegment > 0)
+			{
+				e->segment = TSF_SEGMENT_DELAY;
+				e->segmentIsExponential = TSF_FALSE;
+				e->level = 0.0;
+				e->slope = 0.0;
+				return;
+			}
+			/* fall through */
+		case TSF_SEGMENT_DELAY:
+			e->samplesUntilNextSegment = (int)(e->parameters.attack * outSampleRate);
+			if (e->samplesUntilNextSegment > 0)
+			{
+				if (!e->isAmpEnv)
+				{
+					//mod env attack duration scales with velocity (velocity of 1 is full duration, max velocity is 0.125 times duration)
+					e->samplesUntilNextSegment = (int)(e->parameters.attack * ((145 - e->midiVelocity) / 144.0f) * outSampleRate);
+				}
+				e->segment = TSF_SEGMENT_ATTACK;
+				e->segmentIsExponential = TSF_FALSE;
+				e->level = 0.0f;
+				e->slope = 1.0f / e->samplesUntilNextSegment;
+				return;
+			}
+			/* fall through */
+		case TSF_SEGMENT_ATTACK:
+			e->samplesUntilNextSegment = (int)(e->parameters.hold * outSampleRate);
+			if (e->samplesUntilNextSegment > 0)
+			{
+				e->segment = TSF_SEGMENT_HOLD;
+				e->segmentIsExponential = TSF_FALSE;
+				e->level = 1.0f;
+				e->slope = 0.0f;
+				return;
+			}
+			/* fall through */
+		case TSF_SEGMENT_HOLD:
+			e->samplesUntilNextSegment = (int)(e->parameters.decay * outSampleRate);
+			if (e->samplesUntilNextSegment > 0)
+			{
+				e->segment = TSF_SEGMENT_DECAY;
+				e->level = 1.0f;
+				if (e->isAmpEnv)
+				{
+					// I don't truly understand this; just following what LinuxSampler does.
+					float mysterySlope = -9.226f / e->samplesUntilNextSegment;
+					e->slope = TSF_EXPF(mysterySlope);
+					e->segmentIsExponential = TSF_TRUE;
+					if (e->parameters.sustain > 0.0f)
+					{
+						// Again, this is following LinuxSampler's example, which is similar to
+						// SF2-style decay, where "decay" specifies the time it would take to
+						// get to zero, not to the sustain level.  The SFZ spec is not that
+						// specific about what "decay" means, so perhaps it's really supposed
+						// to specify the time to reach the sustain level.
+						e->samplesUntilNextSegment = (int)(TSF_LOG(e->parameters.sustain) / mysterySlope);
+					}
+				}
+				else
+				{
+					e->slope = -1.0f / e->samplesUntilNextSegment;
+					e->samplesUntilNextSegment = (int)(e->parameters.decay * (1.0f - e->parameters.sustain) * outSampleRate);
+					e->segmentIsExponential = TSF_FALSE;
+				}
+				return;
+			}
+			/* fall through */
+		case TSF_SEGMENT_DECAY:
+			e->segment = TSF_SEGMENT_SUSTAIN;
+			e->level = e->parameters.sustain;
+			e->slope = 0.0f;
+			e->samplesUntilNextSegment = 0x7FFFFFFF;
+			e->segmentIsExponential = TSF_FALSE;
+			return;
+		case TSF_SEGMENT_SUSTAIN:
+			e->segment = TSF_SEGMENT_RELEASE;
+			e->samplesUntilNextSegment = tsf_voice_envelope_release_samples(e, outSampleRate);
+			if (e->isAmpEnv)
+			{
+				// I don't truly understand this; just following what LinuxSampler does.
+				float mysterySlope = -9.226f / e->samplesUntilNextSegment;
+				e->slope = TSF_EXPF(mysterySlope);
+				e->segmentIsExponential = TSF_TRUE;
+			}
+			else
+			{
+				e->slope = -e->level / e->samplesUntilNextSegment;
+				e->segmentIsExponential = TSF_FALSE;
+			}
+			return;
+		case TSF_SEGMENT_RELEASE:
+		default:
+			e->segment = TSF_SEGMENT_DONE;
+			e->segmentIsExponential = TSF_FALSE;
+			e->level = e->slope = 0.0f;
+			e->samplesUntilNextSegment = 0x7FFFFFF;
+	}
+}
+
+static void tsf_voice_envelope_setup(struct tsf_voice_envelope* e, struct tsf_envelope* new_parameters, int midiNoteNumber, short midiVelocity, TSF_BOOL isAmpEnv, float outSampleRate)
+{
+	e->parameters = *new_parameters;
+	if (e->parameters.keynumToHold)
+	{
+		e->parameters.hold += e->parameters.keynumToHold * (60.0f - midiNoteNumber);
+		e->parameters.hold = (e->parameters.hold < -10000.0f ? 0.0f : tsf_timecents2Secsf(e->parameters.hold));
+	}
+	if (e->parameters.keynumToDecay)
+	{
+		e->parameters.decay += e->parameters.keynumToDecay * (60.0f - midiNoteNumber);
+		e->parameters.decay = (e->parameters.decay < -10000.0f ? 0.0f : tsf_timecents2Secsf(e->parameters.decay));
+	}
+	e->midiVelocity = midiVelocity;
+	e->isAmpEnv = isAmpEnv;
+	tsf_voice_envelope_nextsegment(e, TSF_SEGMENT_NONE, outSampleRate);
+}
+
+static void tsf_voice_envelope_process(struct tsf_voice_envelope* e, int numSamples, float outSampleRate)
+{
+	if (e->slope)
+	{
+		if (e->segmentIsExponential) e->level *= TSF_POWF(e->slope, (float)numSamples);
+		else e->level += (e->slope * numSamples);
+	}
+	if ((e->samplesUntilNextSegment -= numSamples) <= 0)
+		tsf_voice_envelope_nextsegment(e, e->segment, outSampleRate);
+}
+
+static void tsf_voice_lowpass_setup(struct tsf_voice_lowpass* e, float Fc)
+{
+	// Lowpass filter from http://www.earlevel.com/main/2012/11/26/biquad-c-source-code/
+	double K = TSF_TAN(TSF_PI * Fc), KK = K * K;
+	double norm = 1 / (1 + K * e->QInv + KK);
+	e->a0 = KK * norm;
+	e->a1 = 2 * e->a0;
+	e->b1 = 2 * (KK - 1) * norm;
+	e->b2 = (1 - K * e->QInv + KK) * norm;
+}
+
+static float tsf_voice_lowpass_process(struct tsf_voice_lowpass* e, double In)
+{
+	double Out = In * e->a0 + e->z1; e->z1 = In * e->a1 + e->z2 - e->b1 * Out; e->z2 = In * e->a0 - e->b2 * Out; return (float)Out;
+}
+
+static void tsf_voice_lfo_setup(struct tsf_voice_lfo* e, float delay, int freqCents, float outSampleRate)
+{
+	e->samplesUntil = (int)(delay * outSampleRate);
+	e->delta = (4.0f * tsf_cents2Hertz((float)freqCents) / outSampleRate);
+	e->level = 0;
+}
+
+static void tsf_voice_lfo_process(struct tsf_voice_lfo* e, int blockSamples)
+{
+	if (e->samplesUntil > blockSamples) { e->samplesUntil -= blockSamples; return; }
+	e->level += e->delta * blockSamples;
+	if      (e->level >  1.0f) { e->delta = -e->delta; e->level =  2.0f - e->level; }
+	else if (e->level < -1.0f) { e->delta = -e->delta; e->level = -2.0f - e->level; }
+}
+
+static void tsf_voice_kill(struct tsf_voice* v)
+{
+	v->playingPreset = -1;
+}
+
+static void tsf_voice_end(tsf* f, struct tsf_voice* v)
+{
+	// if maxVoiceNum is set, assume that voice rendering and note queuing are on separate threads
+	// so to minimize the chance that voice rendering would advance the segment at the same time
+	// we just do it twice here and hope that it sticks
+	int repeats = (f->maxVoiceNum ? 2 : 1);
+	while (repeats--)
+	{
+		tsf_voice_envelope_nextsegment(&v->ampenv, TSF_SEGMENT_SUSTAIN, f->outSampleRate);
+		tsf_voice_envelope_nextsegment(&v->modenv, TSF_SEGMENT_SUSTAIN, f->outSampleRate);
+		if (v->region->loop_mode == TSF_LOOPMODE_SUSTAIN)
+		{
+			// Continue playing, but stop looping.
+			v->loopEnd = v->loopStart;
+		}
+	}
+}
+
+static void tsf_voice_endquick(tsf* f, struct tsf_voice* v)
+{
+	// if maxVoiceNum is set, assume that voice rendering and note queuing are on separate threads
+	// so to minimize the chance that voice rendering would advance the segment at the same time
+	// we just do it twice here and hope that it sticks
+	int repeats = (f->maxVoiceNum ? 2 : 1);
+	while (repeats--)
+	{
+		v->ampenv.parameters.release = 0.0f; tsf_voice_envelope_nextsegment(&v->ampenv, TSF_SEGMENT_SUSTAIN, f->outSampleRate);
+		v->modenv.parameters.release = 0.0f; tsf_voice_envelope_nextsegment(&v->modenv, TSF_SEGMENT_SUSTAIN, f->outSampleRate);
+	}
+}
+
+static void tsf_voice_calcpitchratio(struct tsf_voice* v, float pitchShift, float outSampleRate)
+{
+	double note = v->playingKey + v->region->transpose + v->region->tune / 100.0;
+	double adjustedPitch = v->region->pitch_keycenter + (note - v->region->pitch_keycenter) * (v->region->pitch_keytrack / 100.0);
+	if (pitchShift) adjustedPitch += pitchShift;
+	v->pitchInputTimecents = adjustedPitch * 100.0;
+	v->pitchOutputFactor = v->region->sample_rate / (tsf_timecents2Secsd(v->region->pitch_keycenter * 100.0) * outSampleRate);
+}
+
+static void tsf_voice_render(tsf* f, struct tsf_voice* v, float* outputBuffer, int numSamples)
+{
+	struct tsf_region* region = v->region;
+	float* input = f->fontSamples;
+	float* outL = outputBuffer;
+	float* outR = (f->outputmode == TSF_STEREO_UNWEAVED ? outL + numSamples : TSF_NULL);
+
+	// Cache some values, to give them at least some chance of ending up in registers.
+	TSF_BOOL updateModEnv = (region->modEnvToPitch || region->modEnvToFilterFc);
+	TSF_BOOL updateModLFO = (v->modlfo.delta && (region->modLfoToPitch || region->modLfoToFilterFc || region->modLfoToVolume));
+	TSF_BOOL updateVibLFO = (v->viblfo.delta && (region->vibLfoToPitch));
+	TSF_BOOL isLooping    = (v->loopStart < v->loopEnd);
+	unsigned int tmpLoopStart = v->loopStart, tmpLoopEnd = v->loopEnd;
+	double tmpSampleEndDbl = (double)region->end, tmpLoopEndDbl = (double)tmpLoopEnd + 1.0;
+	double tmpSourceSamplePosition = v->sourceSamplePosition;
+	struct tsf_voice_lowpass tmpLowpass = v->lowpass;
+
+	TSF_BOOL dynamicLowpass = (region->modLfoToFilterFc || region->modEnvToFilterFc);
+	float tmpSampleRate = f->outSampleRate, tmpInitialFilterFc, tmpModLfoToFilterFc, tmpModEnvToFilterFc;
+
+	TSF_BOOL dynamicPitchRatio = (region->modLfoToPitch || region->modEnvToPitch || region->vibLfoToPitch);
+	double pitchRatio;
+	float tmpModLfoToPitch, tmpVibLfoToPitch, tmpModEnvToPitch;
+
+	TSF_BOOL dynamicGain = (region->modLfoToVolume != 0);
+	float noteGain = 0, tmpModLfoToVolume;
+
+	if (dynamicLowpass) tmpInitialFilterFc = (float)region->initialFilterFc, tmpModLfoToFilterFc = (float)region->modLfoToFilterFc, tmpModEnvToFilterFc = (float)region->modEnvToFilterFc;
+	else tmpInitialFilterFc = 0, tmpModLfoToFilterFc = 0, tmpModEnvToFilterFc = 0;
+
+	if (dynamicPitchRatio) pitchRatio = 0, tmpModLfoToPitch = (float)region->modLfoToPitch, tmpVibLfoToPitch = (float)region->vibLfoToPitch, tmpModEnvToPitch = (float)region->modEnvToPitch;
+	else pitchRatio = tsf_timecents2Secsd(v->pitchInputTimecents) * v->pitchOutputFactor, tmpModLfoToPitch = 0, tmpVibLfoToPitch = 0, tmpModEnvToPitch = 0;
+
+	if (dynamicGain) tmpModLfoToVolume = (float)region->modLfoToVolume * 0.1f;
+	else noteGain = tsf_decibelsToGain(v->noteGainDB), tmpModLfoToVolume = 0;
+
+	while (numSamples)
+	{
+		float gainMono, gainLeft, gainRight;
+		int blockSamples = (numSamples > TSF_RENDER_EFFECTSAMPLEBLOCK ? TSF_RENDER_EFFECTSAMPLEBLOCK : numSamples);
+		numSamples -= blockSamples;
+
+		if (dynamicLowpass)
+		{
+			float fres = tmpInitialFilterFc + v->modlfo.level * tmpModLfoToFilterFc + v->modenv.level * tmpModEnvToFilterFc;
+			float lowpassFc = (fres <= 13500 ? tsf_cents2Hertz(fres) / tmpSampleRate : 1.0f);
+			tmpLowpass.active = (lowpassFc < 0.499f);
+			if (tmpLowpass.active) tsf_voice_lowpass_setup(&tmpLowpass, lowpassFc);
+		}
+
+		if (dynamicPitchRatio)
+			pitchRatio = tsf_timecents2Secsd(v->pitchInputTimecents + (v->modlfo.level * tmpModLfoToPitch + v->viblfo.level * tmpVibLfoToPitch + v->modenv.level * tmpModEnvToPitch)) * v->pitchOutputFactor;
+
+		if (dynamicGain)
+			noteGain = tsf_decibelsToGain(v->noteGainDB + (v->modlfo.level * tmpModLfoToVolume));
+
+		gainMono = noteGain * v->ampenv.level;
+
+		// Update EG.
+		tsf_voice_envelope_process(&v->ampenv, blockSamples, tmpSampleRate);
+		if (updateModEnv) tsf_voice_envelope_process(&v->modenv, blockSamples, tmpSampleRate);
+
+		// Update LFOs.
+		if (updateModLFO) tsf_voice_lfo_process(&v->modlfo, blockSamples);
+		if (updateVibLFO) tsf_voice_lfo_process(&v->viblfo, blockSamples);
+
+		switch (f->outputmode)
+		{
+			case TSF_STEREO_INTERLEAVED:
+				gainLeft = gainMono * v->panFactorLeft, gainRight = gainMono * v->panFactorRight;
+				while (blockSamples-- && tmpSourceSamplePosition < tmpSampleEndDbl)
+				{
+					unsigned int pos = (unsigned int)tmpSourceSamplePosition, nextPos = (pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1);
+
+					// Simple linear interpolation.
+					float alpha = (float)(tmpSourceSamplePosition - pos), val = (input[pos] * (1.0f - alpha) + input[nextPos] * alpha);
+
+					// Low-pass filter.
+					if (tmpLowpass.active) val = tsf_voice_lowpass_process(&tmpLowpass, val);
+
+					*outL++ += val * gainLeft;
+					*outL++ += val * gainRight;
+
+					// Next sample.
+					tmpSourceSamplePosition += pitchRatio;
+					if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= (tmpLoopEnd - tmpLoopStart + 1.0);
+				}
+				break;
+
+			case TSF_STEREO_UNWEAVED:
+				gainLeft = gainMono * v->panFactorLeft, gainRight = gainMono * v->panFactorRight;
+				while (blockSamples-- && tmpSourceSamplePosition < tmpSampleEndDbl)
+				{
+					unsigned int pos = (unsigned int)tmpSourceSamplePosition, nextPos = (pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1);
+
+					// Simple linear interpolation.
+					float alpha = (float)(tmpSourceSamplePosition - pos), val = (input[pos] * (1.0f - alpha) + input[nextPos] * alpha);
+
+					// Low-pass filter.
+					if (tmpLowpass.active) val = tsf_voice_lowpass_process(&tmpLowpass, val);
+
+					*outL++ += val * gainLeft;
+					*outR++ += val * gainRight;
+
+					// Next sample.
+					tmpSourceSamplePosition += pitchRatio;
+					if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= (tmpLoopEnd - tmpLoopStart + 1.0);
+				}
+				break;
+
+			case TSF_MONO:
+				while (blockSamples-- && tmpSourceSamplePosition < tmpSampleEndDbl)
+				{
+					unsigned int pos = (unsigned int)tmpSourceSamplePosition, nextPos = (pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1);
+
+					// Simple linear interpolation.
+					float alpha = (float)(tmpSourceSamplePosition - pos), val = (input[pos] * (1.0f - alpha) + input[nextPos] * alpha);
+
+					// Low-pass filter.
+					if (tmpLowpass.active) val = tsf_voice_lowpass_process(&tmpLowpass, val);
+
+					*outL++ += val * gainMono;
+
+					// Next sample.
+					tmpSourceSamplePosition += pitchRatio;
+					if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= (tmpLoopEnd - tmpLoopStart + 1.0);
+				}
+				break;
+		}
+
+		if (tmpSourceSamplePosition >= tmpSampleEndDbl || v->ampenv.segment == TSF_SEGMENT_DONE)
+		{
+			tsf_voice_kill(v);
+			return;
+		}
+	}
+
+	v->sourceSamplePosition = tmpSourceSamplePosition;
+	if (tmpLowpass.active || dynamicLowpass) v->lowpass = tmpLowpass;
+}
+
+TSFDEF tsf* tsf_load(struct tsf_stream* stream)
+{
+	tsf* res = TSF_NULL;
+	struct tsf_riffchunk chunkHead;
+	struct tsf_riffchunk chunkList;
+	struct tsf_hydra hydra;
+	void* rawBuffer = TSF_NULL;
+	float* floatBuffer = TSF_NULL;
+	tsf_u32 smplCount = 0;
+
+	if (!tsf_riffchunk_read(TSF_NULL, &chunkHead, stream) || !TSF_FourCCEquals(chunkHead.id, "sfbk"))
+	{
+		//if (e) *e = TSF_INVALID_NOSF2HEADER;
+		return res;
+	}
+
+	// Read hydra and locate sample data.
+	TSF_MEMSET(&hydra, 0, sizeof(hydra));
+	while (tsf_riffchunk_read(&chunkHead, &chunkList, stream))
+	{
+		struct tsf_riffchunk chunk;
+		if (TSF_FourCCEquals(chunkList.id, "pdta"))
+		{
+			while (tsf_riffchunk_read(&chunkList, &chunk, stream))
+			{
+				#define HandleChunk(chunkName) (TSF_FourCCEquals(chunk.id, #chunkName) && !(chunk.size % chunkName##SizeInFile)) \
+					{ \
+						int num = chunk.size / chunkName##SizeInFile, i; \
+						hydra.chunkName##Num = num; \
+						hydra.chunkName##s = (struct tsf_hydra_##chunkName*)TSF_MALLOC(num * sizeof(struct tsf_hydra_##chunkName)); \
+						if (!hydra.chunkName##s) goto out_of_memory; \
+						for (i = 0; i < num; ++i) tsf_hydra_read_##chunkName(&hydra.chunkName##s[i], stream); \
+					}
+				enum
+				{
+					phdrSizeInFile = 38, pbagSizeInFile =  4, pmodSizeInFile = 10,
+					pgenSizeInFile =  4, instSizeInFile = 22, ibagSizeInFile =  4,
+					imodSizeInFile = 10, igenSizeInFile =  4, shdrSizeInFile = 46
+				};
+				if      HandleChunk(phdr) else if HandleChunk(pbag) else if HandleChunk(pmod)
+				else if HandleChunk(pgen) else if HandleChunk(inst) else if HandleChunk(ibag)
+				else if HandleChunk(imod) else if HandleChunk(igen) else if HandleChunk(shdr)
+				else stream->skip(stream->data, chunk.size);
+				#undef HandleChunk
+			}
+		}
+		else if (TSF_FourCCEquals(chunkList.id, "sdta"))
+		{
+			while (tsf_riffchunk_read(&chunkList, &chunk, stream))
+			{
+				if ((TSF_FourCCEquals(chunk.id, "smpl")
+						#ifdef STB_VORBIS_INCLUDE_STB_VORBIS_H
+						|| TSF_FourCCEquals(chunk.id, "smpo")
+						#endif
+					) && !rawBuffer && !floatBuffer && chunk.size >= sizeof(short))
+				{
+					if (!tsf_load_samples(&rawBuffer, &floatBuffer, &smplCount, &chunk, stream)) goto out_of_memory;
+				}
+				else stream->skip(stream->data, chunk.size);
+			}
+		}
+		else stream->skip(stream->data, chunkList.size);
+	}
+	if (!hydra.phdrs || !hydra.pbags || !hydra.pmods || !hydra.pgens || !hydra.insts || !hydra.ibags || !hydra.imods || !hydra.igens || !hydra.shdrs)
+	{
+		//if (e) *e = TSF_INVALID_INCOMPLETE;
+	}
+	else if (!rawBuffer && !floatBuffer)
+	{
+		//if (e) *e = TSF_INVALID_NOSAMPLEDATA;
+	}
+	else
+	{
+		#ifdef STB_VORBIS_INCLUDE_STB_VORBIS_H
+		if (!floatBuffer && !tsf_decode_sf3_samples(rawBuffer, &floatBuffer, &smplCount, &hydra)) goto out_of_memory;
+		#endif
+		res = (tsf*)TSF_MALLOC(sizeof(tsf));
+		if (res) TSF_MEMSET(res, 0, sizeof(tsf));
+		if (!res || !tsf_load_presets(res, &hydra, smplCount)) goto out_of_memory;
+		res->outSampleRate = 44100.0f;
+		res->fontSamples = floatBuffer;
+		floatBuffer = TSF_NULL; // don't free below
+	}
+	if (0)
+	{
+		out_of_memory:
+		TSF_FREE(res);
+		res = TSF_NULL;
+		//if (e) *e = TSF_OUT_OF_MEMORY;
+	}
+	TSF_FREE(hydra.phdrs); TSF_FREE(hydra.pbags); TSF_FREE(hydra.pmods);
+	TSF_FREE(hydra.pgens); TSF_FREE(hydra.insts); TSF_FREE(hydra.ibags);
+	TSF_FREE(hydra.imods); TSF_FREE(hydra.igens); TSF_FREE(hydra.shdrs);
+	TSF_FREE(rawBuffer);   TSF_FREE(floatBuffer);
+	return res;
+}
+
+TSFDEF tsf* tsf_copy(tsf* f)
+{
+	tsf* res;
+	if (!f) return TSF_NULL;
+	if (!f->refCount)
+	{
+		f->refCount = (int*)TSF_MALLOC(sizeof(int));
+		if (!f->refCount) return TSF_NULL;
+		*f->refCount = 1;
+	}
+	res = (tsf*)TSF_MALLOC(sizeof(tsf));
+	if (!res) return TSF_NULL;
+	TSF_MEMCPY(res, f, sizeof(tsf));
+	res->voices = TSF_NULL;
+	res->voiceNum = 0;
+	res->channels = TSF_NULL;
+	(*res->refCount)++;
+	return res;
+}
+
+TSFDEF void tsf_close(tsf* f)
+{
+	if (!f) return;
+	if (!f->refCount || !--(*f->refCount))
+	{
+		struct tsf_preset *preset = f->presets, *presetEnd = preset + f->presetNum;
+		for (; preset != presetEnd; preset++) TSF_FREE(preset->regions);
+		TSF_FREE(f->presets);
+		TSF_FREE(f->fontSamples);
+		TSF_FREE(f->refCount);
+	}
+	TSF_FREE(f->channels);
+	TSF_FREE(f->voices);
+	TSF_FREE(f);
+}
+
+TSFDEF void tsf_reset(tsf* f)
+{
+	struct tsf_voice *v = f->voices, *vEnd = v + f->voiceNum;
+	for (; v != vEnd; v++)
+		if (v->playingPreset != -1 && (v->ampenv.segment < TSF_SEGMENT_RELEASE || v->ampenv.parameters.release))
+			tsf_voice_endquick(f, v);
+	if (f->channels) { TSF_FREE(f->channels); f->channels = TSF_NULL; }
+}
+
+TSFDEF int tsf_get_presetindex(const tsf* f, int bank, int preset_number)
+{
+	const struct tsf_preset *presets;
+	int i, iMax;
+	for (presets = f->presets, i = 0, iMax = f->presetNum; i < iMax; i++)
+		if (presets[i].preset == preset_number && presets[i].bank == bank)
+			return i;
+	return -1;
+}
+
+TSFDEF int tsf_get_presetcount(const tsf* f)
+{
+	return f->presetNum;
+}
+
+TSFDEF const char* tsf_get_presetname(const tsf* f, int preset)
+{
+	return (preset < 0 || preset >= f->presetNum ? TSF_NULL : f->presets[preset].presetName);
+}
+
+TSFDEF const char* tsf_bank_get_presetname(const tsf* f, int bank, int preset_number)
+{
+	return tsf_get_presetname(f, tsf_get_presetindex(f, bank, preset_number));
+}
+
+TSFDEF void tsf_set_output(tsf* f, enum TSFOutputMode outputmode, int samplerate, float global_gain_db)
+{
+	f->outputmode = outputmode;
+	f->outSampleRate = (float)(samplerate >= 1 ? samplerate : 44100.0f);
+	f->globalGainDB = global_gain_db;
+}
+
+TSFDEF void tsf_set_volume(tsf* f, float global_volume)
+{
+	f->globalGainDB = (global_volume == 1.0f ? 0 : -tsf_gainToDecibels(1.0f / global_volume));
+}
+
+TSFDEF int tsf_set_max_voices(tsf* f, int max_voices)
+{
+	int i = f->voiceNum;
+	int newVoiceNum = (f->voiceNum > max_voices ? f->voiceNum : max_voices);
+	struct tsf_voice *newVoices = (struct tsf_voice*)TSF_REALLOC(f->voices, newVoiceNum * sizeof(struct tsf_voice));
+	if (!newVoices) return 0;
+	f->voices = newVoices;
+	f->voiceNum = f->maxVoiceNum = newVoiceNum;
+	for (; i < max_voices; i++)
+		f->voices[i].playingPreset = -1;
+	return 1;
+}
+
+TSFDEF int tsf_note_on(tsf* f, int preset_index, int key, float vel)
+{
+	short midiVelocity = (short)(vel * 127);
+	unsigned int voicePlayIndex;
+	struct tsf_region *region, *regionEnd;
+
+	if (preset_index < 0 || preset_index >= f->presetNum) return 1;
+	if (vel <= 0.0f) { tsf_note_off(f, preset_index, key); return 1; }
+
+	// Play all matching regions.
+	voicePlayIndex = f->voicePlayIndex++;
+	for (region = f->presets[preset_index].regions, regionEnd = region + f->presets[preset_index].regionNum; region != regionEnd; region++)
+	{
+		struct tsf_voice *voice, *v, *vEnd; TSF_BOOL doLoop; float lowpassFilterQDB, lowpassFc;
+		if (key < region->lokey || key > region->hikey || midiVelocity < region->lovel || midiVelocity > region->hivel) continue;
+
+		voice = TSF_NULL, v = f->voices, vEnd = v + f->voiceNum;
+		if (region->group)
+		{
+			for (; v != vEnd; v++)
+				if (v->playingPreset == preset_index && v->region->group == region->group) tsf_voice_endquick(f, v);
+				else if (v->playingPreset == -1 && !voice) voice = v;
+		}
+		else for (; v != vEnd; v++) if (v->playingPreset == -1) { voice = v; break; }
+
+		if (!voice)
+		{
+			if (f->maxVoiceNum)
+			{
+				// Voices have been pre-allocated and limited to a maximum, try to kill a voice off in its release envelope
+				int bestKillReleaseSamplePos = -999999999;
+				for (v = f->voices; v != vEnd; v++)
+				{
+					if (v->ampenv.segment == TSF_SEGMENT_RELEASE)
+					{
+						// We're looking for the voice furthest into its release
+						int releaseSamplesDone = tsf_voice_envelope_release_samples(&v->ampenv, f->outSampleRate) - v->ampenv.samplesUntilNextSegment;
+						if (releaseSamplesDone > bestKillReleaseSamplePos)
+						{
+							bestKillReleaseSamplePos = releaseSamplesDone;
+							voice = v;
+						}
+					}
+				}
+				if (!voice)
+					continue;
+				tsf_voice_kill(voice);
+			}
+			else
+			{
+				// Allocate more voices so we don't need to kill one off.
+				struct tsf_voice* newVoices;
+				f->voiceNum += 4;
+				newVoices = (struct tsf_voice*)TSF_REALLOC(f->voices, f->voiceNum * sizeof(struct tsf_voice));
+				if (!newVoices) return 0;
+				f->voices = newVoices;
+				voice = &f->voices[f->voiceNum - 4];
+				voice[1].playingPreset = voice[2].playingPreset = voice[3].playingPreset = -1;
+			}
+		}
+
+		voice->region = region;
+		voice->playingPreset = preset_index;
+		voice->playingKey = key;
+		voice->playIndex = voicePlayIndex;
+		voice->heldSustain = 0;
+		voice->noteGainDB = f->globalGainDB - region->attenuation - tsf_gainToDecibels(1.0f / vel);
+
+		if (f->channels)
+		{
+			f->channels->setupVoice(f, voice);
+		}
+		else
+		{
+			tsf_voice_calcpitchratio(voice, 0, f->outSampleRate);
+			// The SFZ spec is silent about the pan curve, but a 3dB pan law seems common. This sqrt() curve matches what Dimension LE does; Alchemy Free seems closer to sin(adjustedPan * pi/2).
+			voice->panFactorLeft  = TSF_SQRTF(0.5f - region->pan);
+			voice->panFactorRight = TSF_SQRTF(0.5f + region->pan);
+		}
+
+		// Offset/end.
+		voice->sourceSamplePosition = region->offset;
+
+		// Loop.
+		doLoop = (region->loop_mode != TSF_LOOPMODE_NONE && region->loop_start < region->loop_end);
+		voice->loopStart = (doLoop ? region->loop_start : 0);
+		voice->loopEnd = (doLoop ? region->loop_end : 0);
+
+		// Setup envelopes.
+		tsf_voice_envelope_setup(&voice->ampenv, &region->ampenv, key, midiVelocity, TSF_TRUE, f->outSampleRate);
+		tsf_voice_envelope_setup(&voice->modenv, &region->modenv, key, midiVelocity, TSF_FALSE, f->outSampleRate);
+
+		// Setup lowpass filter.
+		lowpassFc = (region->initialFilterFc <= 13500 ? tsf_cents2Hertz((float)region->initialFilterFc) / f->outSampleRate : 1.0f);
+		lowpassFilterQDB = region->initialFilterQ / 10.0f;
+		voice->lowpass.QInv = 1.0 / TSF_POW(10.0, (lowpassFilterQDB / 20.0));
+		voice->lowpass.z1 = voice->lowpass.z2 = 0;
+		voice->lowpass.active = (lowpassFc < 0.499f);
+		if (voice->lowpass.active) tsf_voice_lowpass_setup(&voice->lowpass, lowpassFc);
+
+		// Setup LFO filters.
+		tsf_voice_lfo_setup(&voice->modlfo, region->delayModLFO, region->freqModLFO, f->outSampleRate);
+		tsf_voice_lfo_setup(&voice->viblfo, region->delayVibLFO, region->freqVibLFO, f->outSampleRate);
+	}
+	return 1;
+}
+
+TSFDEF int tsf_bank_note_on(tsf* f, int bank, int preset_number, int key, float vel)
+{
+	int preset_index = tsf_get_presetindex(f, bank, preset_number);
+	if (preset_index == -1) return 0;
+	return tsf_note_on(f, preset_index, key, vel);
+}
+
+TSFDEF void tsf_note_off(tsf* f, int preset_index, int key)
+{
+	struct tsf_voice *v = f->voices, *vEnd = v + f->voiceNum, *vMatchFirst = TSF_NULL, *vMatchLast = TSF_NULL;
+	for (; v != vEnd; v++)
+	{
+		//Find the first and last entry in the voices list with matching preset, key and look up the smallest play index
+		if (v->playingPreset != preset_index || v->playingKey != key || v->ampenv.segment >= TSF_SEGMENT_RELEASE) continue;
+		else if (!vMatchFirst || v->playIndex < vMatchFirst->playIndex) vMatchFirst = vMatchLast = v;
+		else if (v->playIndex == vMatchFirst->playIndex) vMatchLast = v;
+	}
+	if (!vMatchFirst) return;
+	for (v = vMatchFirst; v <= vMatchLast; v++)
+	{
+		//Stop all voices with matching preset, key and the smallest play index which was enumerated above
+		if (v != vMatchFirst && v != vMatchLast &&
+			(v->playIndex != vMatchFirst->playIndex || v->playingPreset != preset_index || v->playingKey != key || v->ampenv.segment >= TSF_SEGMENT_RELEASE)) continue;
+		tsf_voice_end(f, v);
+	}
+}
+
+TSFDEF int tsf_bank_note_off(tsf* f, int bank, int preset_number, int key)
+{
+	int preset_index = tsf_get_presetindex(f, bank, preset_number);
+	if (preset_index == -1) return 0;
+	tsf_note_off(f, preset_index, key);
+	return 1;
+}
+
+TSFDEF void tsf_note_off_all(tsf* f)
+{
+	struct tsf_voice *v = f->voices, *vEnd = v + f->voiceNum;
+	for (; v != vEnd; v++) if (v->playingPreset != -1 && v->ampenv.segment < TSF_SEGMENT_RELEASE)
+		tsf_voice_end(f, v);
+}
+
+TSFDEF int tsf_active_voice_count(tsf* f)
+{
+	int count = 0;
+	struct tsf_voice *v = f->voices, *vEnd = v + f->voiceNum;
+	for (; v != vEnd; v++) if (v->playingPreset != -1) count++;
+	return count;
+}
+
+TSFDEF void tsf_render_short(tsf* f, short* buffer, int samples, int flag_mixing)
+{
+	float outputSamples[TSF_RENDER_SHORTBUFFERBLOCK];
+	int channels = (f->outputmode == TSF_MONO ? 1 : 2), maxChannelSamples = TSF_RENDER_SHORTBUFFERBLOCK / channels;
+	while (samples > 0)
+	{
+		int channelSamples = (samples > maxChannelSamples ? maxChannelSamples : samples);
+		short* bufferEnd = buffer + channelSamples * channels;
+		float *floatSamples = outputSamples;
+		tsf_render_float(f, floatSamples, channelSamples, TSF_FALSE);
+		samples -= channelSamples;
+
+		if (flag_mixing)
+			while (buffer != bufferEnd)
+			{
+				float v = *floatSamples++;
+				int vi = *buffer + (v < -1.00004566f ? (int)-32768 : (v > 1.00001514f ? (int)32767 : (int)(v * 32767.5f)));
+				*buffer++ = (vi < -32768 ? (short)-32768 : (vi > 32767 ? (short)32767 : (short)vi));
+			}
+		else
+			while (buffer != bufferEnd)
+			{
+				float v = *floatSamples++;
+				*buffer++ = (v < -1.00004566f ? (short)-32768 : (v > 1.00001514f ? (short)32767 : (short)(v * 32767.5f)));
+			}
+	}
+}
+
+TSFDEF void tsf_render_float(tsf* f, float* buffer, int samples, int flag_mixing)
+{
+	struct tsf_voice *v = f->voices, *vEnd = v + f->voiceNum;
+	if (!flag_mixing) TSF_MEMSET(buffer, 0, (f->outputmode == TSF_MONO ? 1 : 2) * sizeof(float) * samples);
+	for (; v != vEnd; v++)
+		if (v->playingPreset != -1)
+			tsf_voice_render(f, v, buffer, samples);
+}
+
+static void tsf_channel_setup_voice(tsf* f, struct tsf_voice* v)
+{
+	struct tsf_channel* c = &f->channels->channels[f->channels->activeChannel];
+	float newpan = v->region->pan + c->panOffset;
+	v->playingChannel = f->channels->activeChannel;
+	v->noteGainDB += c->gainDB;
+	tsf_voice_calcpitchratio(v, (c->pitchWheel == 8192 ? c->tuning : ((c->pitchWheel / 16383.0f * c->pitchRange * 2.0f) - c->pitchRange + c->tuning)), f->outSampleRate);
+	if      (newpan <= -0.5f) { v->panFactorLeft = 1.0f; v->panFactorRight = 0.0f; }
+	else if (newpan >=  0.5f) { v->panFactorLeft = 0.0f; v->panFactorRight = 1.0f; }
+	else { v->panFactorLeft = TSF_SQRTF(0.5f - newpan); v->panFactorRight = TSF_SQRTF(0.5f + newpan); }
+}
+
+static struct tsf_channel* tsf_channel_init(tsf* f, int channel)
+{
+	int i;
+	if (f->channels && channel < f->channels->channelNum) return &f->channels->channels[channel];
+	if (!f->channels)
+	{
+		f->channels = (struct tsf_channels*)TSF_MALLOC(sizeof(struct tsf_channels) + sizeof(struct tsf_channel) * channel);
+		if (!f->channels) return TSF_NULL;
+		f->channels->setupVoice = &tsf_channel_setup_voice;
+		f->channels->channelNum = 0;
+		f->channels->activeChannel = 0;
+	}
+	else
+	{
+		struct tsf_channels *newChannels = (struct tsf_channels*)TSF_REALLOC(f->channels, sizeof(struct tsf_channels) + sizeof(struct tsf_channel) * channel);
+		if (!newChannels) return TSF_NULL;
+		f->channels = newChannels;
+	}
+	i = f->channels->channelNum;
+	f->channels->channelNum = channel + 1;
+	for (; i <= channel; i++)
+	{
+		struct tsf_channel* c = &f->channels->channels[i];
+		c->presetIndex = c->bank = 0;
+		c->pitchWheel = c->midiPan = 8192;
+		c->midiVolume = c->midiExpression = 16383;
+		c->midiRPN = 0xFFFF;
+		c->midiData = c->sustain = 0;
+		c->panOffset = 0.0f;
+		c->gainDB = 0.0f;
+		c->pitchRange = 2.0f;
+		c->tuning = 0.0f;
+	}
+	return &f->channels->channels[channel];
+}
+
+static void tsf_channel_applypitch(tsf* f, int channel, struct tsf_channel* c)
+{
+	struct tsf_voice *v, *vEnd;
+	float pitchShift = (c->pitchWheel == 8192 ? c->tuning : ((c->pitchWheel / 16383.0f * c->pitchRange * 2.0f) - c->pitchRange + c->tuning));
+	for (v = f->voices, vEnd = v + f->voiceNum; v != vEnd; v++)
+		if (v->playingPreset != -1 && v->playingChannel == channel)
+			tsf_voice_calcpitchratio(v, pitchShift, f->outSampleRate);
+}
+
+TSFDEF int tsf_channel_set_presetindex(tsf* f, int channel, int preset_index)
+{
+	struct tsf_channel *c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	c->presetIndex = (unsigned short)preset_index;
+	return 1;
+}
+
+TSFDEF int tsf_channel_set_presetnumber(tsf* f, int channel, int preset_number, int flag_mididrums)
+{
+	int preset_index;
+	struct tsf_channel *c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	if (flag_mididrums)
+	{
+		preset_index = tsf_get_presetindex(f, 128 | (c->bank & 0x7FFF), preset_number);
+		if (preset_index == -1) preset_index = tsf_get_presetindex(f, 128, preset_number);
+		if (preset_index == -1) preset_index = tsf_get_presetindex(f, 128, 0);
+		if (preset_index == -1) preset_index = tsf_get_presetindex(f, (c->bank & 0x7FFF), preset_number);
+	}
+	else preset_index = tsf_get_presetindex(f, (c->bank & 0x7FFF), preset_number);
+	if (preset_index == -1) preset_index = tsf_get_presetindex(f, 0, preset_number);
+	if (preset_index != -1)
+	{
+		c->presetIndex = (unsigned short)preset_index;
+		return 1;
+	}
+	return 0;
+}
+
+TSFDEF int tsf_channel_set_bank(tsf* f, int channel, int bank)
+{
+	struct tsf_channel *c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	c->bank = (unsigned short)bank;
+	return 1;
+}
+
+TSFDEF int tsf_channel_set_bank_preset(tsf* f, int channel, int bank, int preset_number)
+{
+	int preset_index;
+	struct tsf_channel *c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	preset_index = tsf_get_presetindex(f, bank, preset_number);
+	if (preset_index == -1) return 0;
+	c->presetIndex = (unsigned short)preset_index;
+	c->bank = (unsigned short)bank;
+	return 1;
+}
+
+TSFDEF int tsf_channel_set_pan(tsf* f, int channel, float pan)
+{
+	struct tsf_voice *v, *vEnd;
+	struct tsf_channel *c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	for (v = f->voices, vEnd = v + f->voiceNum; v != vEnd; v++)
+		if (v->playingPreset != -1 && v->playingChannel == channel)
+		{
+			float newpan = v->region->pan + pan - 0.5f;
+			if      (newpan <= -0.5f) { v->panFactorLeft = 1.0f; v->panFactorRight = 0.0f; }
+			else if (newpan >=  0.5f) { v->panFactorLeft = 0.0f; v->panFactorRight = 1.0f; }
+			else { v->panFactorLeft = TSF_SQRTF(0.5f - newpan); v->panFactorRight = TSF_SQRTF(0.5f + newpan); }
+		}
+	c->panOffset = pan - 0.5f;
+	return 1;
+}
+
+TSFDEF int tsf_channel_set_volume(tsf* f, int channel, float volume)
+{
+	float gainDB = tsf_gainToDecibels(volume), gainDBChange;
+	struct tsf_voice *v, *vEnd;
+	struct tsf_channel *c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	if (gainDB == c->gainDB) return 1;
+	for (v = f->voices, vEnd = v + f->voiceNum, gainDBChange = gainDB - c->gainDB; v != vEnd; v++)
+		if (v->playingPreset != -1 && v->playingChannel == channel)
+			v->noteGainDB += gainDBChange;
+	c->gainDB = gainDB;
+	return 1;
+}
+
+TSFDEF int tsf_channel_set_pitchwheel(tsf* f, int channel, int pitch_wheel)
+{
+	struct tsf_channel *c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	if (c->pitchWheel == pitch_wheel) return 1;
+	c->pitchWheel = (unsigned short)pitch_wheel;
+	tsf_channel_applypitch(f, channel, c);
+	return 1;
+}
+
+TSFDEF int tsf_channel_set_pitchrange(tsf* f, int channel, float pitch_range)
+{
+	struct tsf_channel *c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	if (c->pitchRange == pitch_range) return 1;
+	c->pitchRange = pitch_range;
+	if (c->pitchWheel != 8192) tsf_channel_applypitch(f, channel, c);
+	return 1;
+}
+
+TSFDEF int tsf_channel_set_tuning(tsf* f, int channel, float tuning)
+{
+	struct tsf_channel *c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	if (c->tuning == tuning) return 1;
+	c->tuning = tuning;
+	tsf_channel_applypitch(f, channel, c);
+	return 1;
+}
+
+TSFDEF int tsf_channel_set_sustain(tsf* f, int channel, int flag_sustain)
+{
+	struct tsf_channel *c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	if (!c->sustain == !flag_sustain) return 1;
+	c->sustain = (unsigned short)(flag_sustain != 0);
+	//Turning on sustain does no action now, just starts note_off behaving differently
+	if (flag_sustain) return 1;
+	//Turning off sustain, actually end voices that got a note_off and were set to heldSustain status
+	struct tsf_voice *v = f->voices, *vEnd = v + f->voiceNum;
+	for (; v != vEnd; v++)
+		if (v->playingPreset != -1 && v->playingChannel == channel && v->ampenv.segment < TSF_SEGMENT_RELEASE && v->heldSustain)
+			tsf_voice_end(f, v);
+	return 1;
+}
+
+TSFDEF int tsf_channel_note_on(tsf* f, int channel, int key, float vel)
+{
+	if (!f->channels || channel >= f->channels->channelNum) return 1;
+	f->channels->activeChannel = channel;
+	if (!vel)
+	{
+		tsf_channel_note_off(f, channel, key);
+		return 1;
+	}
+	return tsf_note_on(f, f->channels->channels[channel].presetIndex, key, vel);
+}
+
+TSFDEF void tsf_channel_note_off(tsf* f, int channel, int key)
+{
+	unsigned sustain;
+	struct tsf_voice *v = f->voices, *vEnd = v + f->voiceNum, *vMatchFirst = TSF_NULL, *vMatchLast = TSF_NULL;
+	for (; v != vEnd; v++)
+	{
+		//Find the first and last entry in the voices list with matching channel, key and look up the smallest play index
+		if (v->playingPreset == -1 || v->playingChannel != channel || v->playingKey != key || v->ampenv.segment >= TSF_SEGMENT_RELEASE || v->heldSustain) continue;
+		else if (!vMatchFirst || v->playIndex < vMatchFirst->playIndex) vMatchFirst = vMatchLast = v;
+		else if (v->playIndex == vMatchFirst->playIndex) vMatchLast = v;
+	}
+	if (!vMatchFirst) return;
+	for (sustain = f->channels->channels[channel].sustain, v = vMatchFirst; v <= vMatchLast; v++)
+	{
+		//Stop all voices with matching channel, key and the smallest play index which was enumerated above
+		if (v != vMatchFirst && v != vMatchLast &&
+			(v->playIndex != vMatchFirst->playIndex || v->playingPreset == -1 || v->playingChannel != channel || v->playingKey != key || v->ampenv.segment >= TSF_SEGMENT_RELEASE)) continue;
+		//Don't turn off if sustain is active, just mark as held by sustain so we don't forget it
+		if (sustain)
+			v->heldSustain = 1;
+		else
+			tsf_voice_end(f, v);
+	}
+}
+
+TSFDEF void tsf_channel_note_off_all(tsf* f, int channel)
+{
+	//Ignore sustain channel settings, note_off_all overrides
+	struct tsf_voice *v = f->voices, *vEnd = v + f->voiceNum;
+	for (; v != vEnd; v++)
+		if (v->playingPreset != -1 && v->playingChannel == channel && v->ampenv.segment < TSF_SEGMENT_RELEASE)
+			tsf_voice_end(f, v);
+}
+
+TSFDEF void tsf_channel_sounds_off_all(tsf* f, int channel)
+{
+	struct tsf_voice *v = f->voices, *vEnd = v + f->voiceNum;
+	for (; v != vEnd; v++)
+		if (v->playingPreset != -1 && v->playingChannel == channel && (v->ampenv.segment < TSF_SEGMENT_RELEASE || v->ampenv.parameters.release))
+			tsf_voice_endquick(f, v);
+}
+
+TSFDEF int tsf_channel_midi_control(tsf* f, int channel, int controller, int control_value)
+{
+	struct tsf_channel* c = tsf_channel_init(f, channel);
+	if (!c) return 0;
+	switch (controller)
+	{
+		case   7 /*VOLUME_MSB*/      : c->midiVolume     = (unsigned short)((c->midiVolume     & 0x7F  ) | (control_value << 7)); goto TCMC_SET_VOLUME;
+		case  39 /*VOLUME_LSB*/      : c->midiVolume     = (unsigned short)((c->midiVolume     & 0x3F80) |  control_value);       goto TCMC_SET_VOLUME;
+		case  11 /*EXPRESSION_MSB*/  : c->midiExpression = (unsigned short)((c->midiExpression & 0x7F  ) | (control_value << 7)); goto TCMC_SET_VOLUME;
+		case  43 /*EXPRESSION_LSB*/  : c->midiExpression = (unsigned short)((c->midiExpression & 0x3F80) |  control_value);       goto TCMC_SET_VOLUME;
+		case  10 /*PAN_MSB*/         : c->midiPan        = (unsigned short)((c->midiPan        & 0x7F  ) | (control_value << 7)); goto TCMC_SET_PAN;
+		case  42 /*PAN_LSB*/         : c->midiPan        = (unsigned short)((c->midiPan        & 0x3F80) |  control_value);       goto TCMC_SET_PAN;
+		case   6 /*DATA_ENTRY_MSB*/  : c->midiData       = (unsigned short)((c->midiData       & 0x7F)   | (control_value << 7)); goto TCMC_SET_DATA;
+		case  38 /*DATA_ENTRY_LSB*/  : c->midiData       = (unsigned short)((c->midiData       & 0x3F80) |  control_value);       goto TCMC_SET_DATA;
+		case   0 /*BANK_SELECT_MSB*/ : c->bank = (unsigned short)(0x8000 | control_value); return 1; //bank select MSB alone acts like LSB
+		case  32 /*BANK_SELECT_LSB*/ : c->bank = (unsigned short)((c->bank & 0x8000 ? ((c->bank & 0x7F) << 7) : 0) | control_value); return 1;
+		case 101 /*RPN_MSB*/         : c->midiRPN = (unsigned short)(((c->midiRPN == 0xFFFF ? 0 : c->midiRPN) & 0x7F  ) | (control_value << 7)); return 1;
+		case 100 /*RPN_LSB*/         : c->midiRPN = (unsigned short)(((c->midiRPN == 0xFFFF ? 0 : c->midiRPN) & 0x3F80) |  control_value); return 1;
+		case  98 /*NRPN_LSB*/        : c->midiRPN = 0xFFFF; return 1;
+		case  99 /*NRPN_MSB*/        : c->midiRPN = 0xFFFF; return 1;
+		case  64 /*SUSTAIN*/         : tsf_channel_set_sustain(f, channel, (int)(control_value >= 64)); return 1;
+		case 120 /*ALL_SOUND_OFF*/   : tsf_channel_sounds_off_all(f, channel); return 1;
+		case 123 /*ALL_NOTES_OFF*/   : tsf_channel_note_off_all(f, channel);   return 1;
+		case 121 /*ALL_CTRL_OFF*/    :
+			c->midiVolume = c->midiExpression = 16383;
+			c->midiPan = 8192;
+			c->bank = 0;
+			c->midiRPN = 0xFFFF;
+			c->midiData = 0;
+			tsf_channel_set_volume(f, channel, 1.0f);
+			tsf_channel_set_pan(f, channel, 0.5f);
+			tsf_channel_set_pitchrange(f, channel, 2.0f);
+			tsf_channel_set_tuning(f, channel, 0);
+			return 1;
+	}
+	return 1;
+TCMC_SET_VOLUME:
+	//Raising to the power of 3 seems to result in a decent sounding volume curve for MIDI
+	tsf_channel_set_volume(f, channel, TSF_POWF((c->midiVolume / 16383.0f) * (c->midiExpression / 16383.0f), 3.0f));
+	return 1;
+TCMC_SET_PAN:
+	tsf_channel_set_pan(f, channel, c->midiPan / 16383.0f);
+	return 1;
+TCMC_SET_DATA:
+	if      (c->midiRPN == 0) tsf_channel_set_pitchrange(f, channel, (c->midiData >> 7) + 0.01f * (c->midiData & 0x7F));
+	else if (c->midiRPN == 1) tsf_channel_set_tuning(f, channel, (int)c->tuning + ((float)c->midiData - 8192.0f) / 8192.0f); //fine tune
+	else if (c->midiRPN == 2 && controller == 6) tsf_channel_set_tuning(f, channel, ((float)control_value - 64.0f) + (c->tuning - (int)c->tuning)); //coarse tune
+	return 1;
+}
+
+TSFDEF int tsf_channel_get_preset_index(tsf* f, int channel)
+{
+	return (f->channels && channel < f->channels->channelNum ? f->channels->channels[channel].presetIndex : 0);
+}
+
+TSFDEF int tsf_channel_get_preset_bank(tsf* f, int channel)
+{
+	return (f->channels && channel < f->channels->channelNum ? (f->channels->channels[channel].bank & 0x7FFF) : 0);
+}
+
+TSFDEF int tsf_channel_get_preset_number(tsf* f, int channel)
+{
+	return (f->channels && channel < f->channels->channelNum ? f->presets[f->channels->channels[channel].presetIndex].preset : 0);
+}
+
+TSFDEF float tsf_channel_get_pan(tsf* f, int channel)
+{
+	return (f->channels && channel < f->channels->channelNum ? f->channels->channels[channel].panOffset - 0.5f : 0.5f);
+}
+
+TSFDEF float tsf_channel_get_volume(tsf* f, int channel)
+{
+	return (f->channels && channel < f->channels->channelNum ? tsf_decibelsToGain(f->channels->channels[channel].gainDB) : 1.0f);
+}
+
+TSFDEF int tsf_channel_get_pitchwheel(tsf* f, int channel)
+{
+	return (f->channels && channel < f->channels->channelNum ? f->channels->channels[channel].pitchWheel : 8192);
+}
+
+TSFDEF float tsf_channel_get_pitchrange(tsf* f, int channel)
+{
+	return (f->channels && channel < f->channels->channelNum ? f->channels->channels[channel].pitchRange : 2.0f);
+}
+
+TSFDEF float tsf_channel_get_tuning(tsf* f, int channel)
+{
+	return (f->channels && channel < f->channels->channelNum ? f->channels->channels[channel].tuning : 0.0f);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //TSF_IMPLEMENTATION

--- a/include/interpreter/TonInterpreter.h
+++ b/include/interpreter/TonInterpreter.h
@@ -1,84 +1,94 @@
 #pragma once
 
+
+
 #include "TonBaseVisitor.h"
 #include "core/Timeline.h"
 #include "core/Scope.h"
-#include <map>
+#include <unordered_map>
+#include <unordered_set>
 #include <string>
 #include <any>
 #include <vector>
 #include <exception>
 
+struct tsf;
+
 class ReturnException : public std::exception{
-    public:
-        std::any returnValue;
-        ReturnException(std::any val) : returnValue(std::move(val)){}
+public:
+    std::any returnValue;
+    ReturnException(std::any val) : returnValue(std::move(val)){}
 };
 class TonInterpreter: public TonBaseVisitor {
-    private:
-        std::shared_ptr<Scope<std::any>> currentScope;
-        static constexpr int MAX_STACK_DEPTH = 1000;
-        int currentStackDepth;
+private:
+    tsf* soundFont = nullptr;
+    std::unordered_map<std::string, Instrument> loadedInstruments;
+    static const std::unordered_map<std::string, int> SAMPLE_INSTRUMENTS;
+    static const std::unordered_set<std::string> SYNTHS;
 
-        struct BreakException : public std::exception {};
-        struct ContinueException : public std::exception {};
+    std::shared_ptr<Scope<std::any>> currentScope;
+    static constexpr int MAX_STACK_DEPTH = 1000;
+    int currentStackDepth;
 
-        std::any executeFunctionLogic(const std:: string& funcName, const std::vector<TonParser::ExprContext*>& argsCtx);
-        void validateStackDepth();
+    struct BreakException : public std::exception {};
+    struct ContinueException : public std::exception {};
 
-    public:
-        TonInterpreter() : currentStackDepth{0} {
-            currentScope = std::make_shared<Scope<std::any>>();
-        }
-        
-        std::any visitProgram(TonParser::ProgramContext *ctx) override;
-        std::any visitBlock(TonParser::BlockContext *ctx) override;
-        std::any visitStatement(TonParser::StatementContext *ctx) override;
-        std::any visitVarDecl(TonParser::VarDeclContext *ctx) override;
+    std::any executeFunctionLogic(const std:: string& funcName, const std::vector<TonParser::ExprContext*>& argsCtx);
+    void validateStackDepth();
 
-        std::any visitTrackDecl(TonParser::TrackDeclContext *ctx) override;
+public:
+    TonInterpreter();
+    ~TonInterpreter();
 
-        std::any visitAssignment(TonParser::AssignmentContext *ctx) override;
-        std::any visitArrayExpr(TonParser::ArrayExprContext *ctx);
-        std::any visitTrackEventExpr(TonParser::TrackEventExprContext *ctx);
-        std::any visitShoutStat(TonParser::ShoutStatContext *ctx) override;
-        std::any visitSaveStat(TonParser::SaveStatContext *ctx) override;
-        std::any visitCharValExpr(TonParser::CharValExprContext *ctx) override;
-        std::any visitTargetExpr(TonParser::TargetExprContext *ctx) override;
+    std::any visitProgram(TonParser::ProgramContext *ctx) override;
+    std::any visitBlock(TonParser::BlockContext *ctx) override;
+    std::any visitStatement(TonParser::StatementContext *ctx) override;
+    std::any visitVarDecl(TonParser::VarDeclContext *ctx) override;
 
-        std::any visitCreateSoundExpr(TonParser::CreateSoundExprContext *ctx);
-        std::any visitStringValExpr(TonParser::StringValExprContext *ctx) override;
-        std::any visitNoteValExpr(TonParser::NoteValExprContext *ctx) override;
-        std::any visitIntValExpr(TonParser::IntValExprContext *ctx) override;
-        std::any visitAudioOpStat(TonParser::AudioOpStatContext *ctx) override;
-        std::any visitIsolateExpr(TonParser::IsolateExprContext *ctx) override;
+    std::any visitTrackDecl(TonParser::TrackDeclContext *ctx) override;
+
+    std::any visitAssignment(TonParser::AssignmentContext *ctx) override;
+    std::any visitArrayExpr(TonParser::ArrayExprContext *ctx) override;
+    std::any visitTrackEventExpr(TonParser::TrackEventExprContext *ctx) override;
+    std::any visitShoutStat(TonParser::ShoutStatContext *ctx) override;
+    std::any visitSaveStat(TonParser::SaveStatContext *ctx) override;
+    std::any visitCharValExpr(TonParser::CharValExprContext *ctx) override;
+    std::any visitTargetExpr(TonParser::TargetExprContext *ctx) override;
+
+    std::any visitHeader(TonParser::HeaderContext *ctx) override;
+    std::any visitCreateSoundExpr(TonParser::CreateSoundExprContext *ctx) override;
+    std::any visitStringValExpr(TonParser::StringValExprContext *ctx) override;
+    std::any visitNoteValExpr(TonParser::NoteValExprContext *ctx) override;
+    std::any visitIntValExpr(TonParser::IntValExprContext *ctx) override;
+    std::any visitAudioOpStat(TonParser::AudioOpStatContext *ctx) override;
+    std::any visitIsolateExpr(TonParser::IsolateExprContext *ctx) override;
 
     // logic operations
-        std::any visitBoolValExpr(TonParser::BoolValExprContext *ctx) override;
-        std::any visitNotExpr(TonParser::NotExprContext *ctx) override;
-        std::any visitAndExpr(TonParser::AndExprContext *ctx) override;
-        std::any visitOrExpr(TonParser::OrExprContext *ctx) override;
-        std::any visitRelationalExpr(TonParser::RelationalExprContext *ctx) override;
+    std::any visitBoolValExpr(TonParser::BoolValExprContext *ctx) override;
+    std::any visitNotExpr(TonParser::NotExprContext *ctx) override;
+    std::any visitAndExpr(TonParser::AndExprContext *ctx) override;
+    std::any visitOrExpr(TonParser::OrExprContext *ctx) override;
+    std::any visitRelationalExpr(TonParser::RelationalExprContext *ctx) override;
 
-    // bracketing (is that a word in english xD?)
-        std::any visitParensExpr(TonParser::ParensExprContext *ctx) override;
+    // bracketing
+    std::any visitParensExpr(TonParser::ParensExprContext *ctx) override;
 
     // math
-        std::any visitUnaryExpr(TonParser::UnaryExprContext *ctx) override;
-        std::any visitMulDivExpr(TonParser::MulDivExprContext *ctx) override;
-        std::any visitAddSubMixExpr(TonParser::AddSubMixExprContext *ctx) override;
-        std::any visitConcatExpr(TonParser::ConcatExprContext *ctx) override;
-        std::any visitNumValExpr(TonParser::NumValExprContext *ctx) override;
+    std::any visitUnaryExpr(TonParser::UnaryExprContext *ctx) override;
+    std::any visitMulDivExpr(TonParser::MulDivExprContext *ctx) override;
+    std::any visitAddSubMixExpr(TonParser::AddSubMixExprContext *ctx) override;
+    std::any visitConcatExpr(TonParser::ConcatExprContext *ctx) override;
+    std::any visitNumValExpr(TonParser::NumValExprContext *ctx) override;
 
-        std::any visitLoopStat(TonParser::LoopStatContext *ctx) override;
-        std::any visitUntilStat(TonParser::UntilStatContext *ctx) override;
-        std::any visitBreakStat(TonParser::BreakStatContext *ctx) override;
-        std::any visitContinueStat(TonParser::ContinueStatContext *ctx) override;
-        //functions
-        std::any visitFuncDef(TonParser::FuncDefContext *ctx) override;
-        std::any visitFunctionCallExpr(TonParser::FunctionCallExprContext *ctx) override;
-        std::any visitCallStat(TonParser::CallStatContext *ctx) override;
-        std::any visitReturnStat(TonParser::ReturnStatContext *ctx) override;
+    std::any visitLoopStat(TonParser::LoopStatContext *ctx) override;
+    std::any visitUntilStat(TonParser::UntilStatContext *ctx) override;
+    std::any visitBreakStat(TonParser::BreakStatContext *ctx) override;
+    std::any visitContinueStat(TonParser::ContinueStatContext *ctx) override;
+    //functions
+    std::any visitFuncDef(TonParser::FuncDefContext *ctx) override;
+    std::any visitFunctionCallExpr(TonParser::FunctionCallExprContext *ctx) override;
+    std::any visitCallStat(TonParser::CallStatContext *ctx) override;
+    std::any visitReturnStat(TonParser::ReturnStatContext *ctx) override;
 
-        std::any visitIfStat(TonParser::IfStatContext *ctx) override;
+    std::any visitIfStat(TonParser::IfStatContext *ctx) override;
 };

--- a/include/interpreter/TonInterpreter.h
+++ b/include/interpreter/TonInterpreter.h
@@ -5,12 +5,15 @@
 #include "TonBaseVisitor.h"
 #include "core/Timeline.h"
 #include "core/Scope.h"
+
+#include <filesystem>
 #include <unordered_map>
 #include <unordered_set>
 #include <string>
 #include <any>
 #include <vector>
 #include <exception>
+#include <cstdlib>
 
 struct tsf;
 
@@ -21,6 +24,7 @@ public:
 };
 class TonInterpreter: public TonBaseVisitor {
 private:
+    std::string findSoundFontPath();
     tsf* soundFont = nullptr;
     std::unordered_map<std::string, Instrument> loadedInstruments;
     static const std::unordered_map<std::string, int> SAMPLE_INSTRUMENTS;

--- a/src/interpreter/TonInterpreter.cpp
+++ b/src/interpreter/TonInterpreter.cpp
@@ -390,59 +390,33 @@ std::any TonInterpreter::visitSaveStat(TonParser::SaveStatContext *ctx) {
     std::string fileName = rawFileName.substr(1, rawFileName.length() - 2);
     std::any exportedValue = visit(ctx->expr());
 
+    Sound soundToSave;
+
     if (exportedValue.type() == typeid(Sound)) {
-        Sound soundToSave = std::any_cast<Sound>(exportedValue);
-        AudioFile<float> audioFile;
-        audioFile.setNumChannels(1);
-        audioFile.setNumSamplesPerChannel(soundToSave.samples.size());
-        audioFile.setSampleRate(soundToSave.sampleRate);
-        audioFile.samples[0] = soundToSave.samples;
-        
-        if (audioFile.save(fileName)) {
-            std::cout << ">>> [SYSTEM] Successfully exported SOUND to: " << fileName << std::endl;
-        } else throw std::runtime_error("Error: Failed to write WAV.");
+        soundToSave = std::any_cast<Sound>(exportedValue);
     } 
     else if (exportedValue.type() == typeid(Timeline)) {
-  
         Timeline tl = std::any_cast<Timeline>(exportedValue);
-        int sampleRate = 44100;
-        int maxSamples = sampleRate; 
-
-   
-        for (const auto& pair : tl.tracks) {
-            if (pair.second.isMuted) continue;
-            for (const auto& ev : pair.second.events) {
-                int endSample = (ev.startTimeMs / 1000.0) * sampleRate + ev.sound.samples.size();
-                if (endSample > maxSamples) maxSamples = endSample;
-            }
-        }
-
-        std::vector<double> mixedSamples(maxSamples, 0.0);
-
-    
-        for (const auto& pair : tl.tracks) {
-            if (pair.second.isMuted) continue;
-            for (const auto& ev : pair.second.events) {
-                int startSample = (ev.startTimeMs / 1000.0) * sampleRate;
-                for (size_t i = 0; i < ev.sound.samples.size(); ++i) {
-                    mixedSamples[startSample + i] += ev.sound.samples[i];
-                }
-            }
-        }
-
-
-        AudioFile<double> audioFile;
-        audioFile.setNumChannels(1);
-        audioFile.setSampleRate(sampleRate);
-        audioFile.setNumSamplesPerChannel(maxSamples);
-        audioFile.samples[0] = mixedSamples;
-        
-        if (audioFile.save(fileName)) {
-            std::cout << ">>> [SYSTEM] Successfully mixed and exported TIMELINE to: " << fileName << std::endl;
-        } else throw std::runtime_error("Error: Failed to write WAV.");
+        soundToSave = tl.renderFinalSound(); 
     }
     else {
-        throw std::runtime_error("Error: !save command requires a SOUND or TIMELINE type.");
+        size_t line = ctx->getStart()->getLine();
+        throw std::runtime_error("Line " + std::to_string(line) + ": !save command requires a SOUND or TIMELINE type.");
+    }
+
+    soundToSave.normalize();
+
+    AudioFile<float> audioFile;
+    audioFile.setNumChannels(1);
+    audioFile.setNumSamplesPerChannel(soundToSave.samples.size());
+    audioFile.setSampleRate(Sound::sampleRate);
+    audioFile.samples[0] = soundToSave.samples;
+        
+    if (audioFile.save(fileName)) {
+        std::cout << ">>> [SYSTEM] Successfully exported SOUND to: " << fileName << std::endl;
+    } 
+    else {
+        throw std::runtime_error("Error: Failed to write WAV.");
     }
 
     return {};
@@ -456,7 +430,31 @@ std::any TonInterpreter::visitCreateSoundExpr(TonParser::CreateSoundExprContext 
 
     Note note = std::any_cast<Note>(arg1);;
     int durationMs = std::any_cast<int>(arg2);;
+    float volume = 0.5f;
 
+    if (ctx->expr().size() > 2) {
+        std::any arg3 = visit(ctx->expr(2));
+        if (arg3.type() == typeid(int)) {
+            volume = static_cast<float>(std::any_cast<int>(arg3));
+        }
+        else if (arg3.type() == typeid(double)) {
+            volume = static_cast<float>(std::any_cast<double>(arg3));
+        }
+        else if (arg3.type() == typeid(float)) {
+            volume = std::any_cast<float>(arg3);
+        }
+        else {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": Volume must be a number in range [0, 2].");
+        }
+        if (volume < 0.0f || volume > 2.0f) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": Volume must be a number in range [0, 2]. Given: " + std::to_string(volume));
+        }
+        volume /= 2;
+    }
     Sound generatedSound;
     int totalSamples = (durationMs / 1000.0) * generatedSound.sampleRate;
 
@@ -482,7 +480,6 @@ std::any TonInterpreter::visitCreateSoundExpr(TonParser::CreateSoundExprContext 
         }
     }
     else if (instr.getType() == InstrumentType::SoundFont) {
-        std::cout << instr.getName();
         if (!soundFont) throw std::runtime_error("SoundFont library is not initialized.");
         int realPresetIndex = tsf_get_presetindex(soundFont, 0, instr.getMidiPresetIndex());
 
@@ -491,9 +488,8 @@ std::any TonInterpreter::visitCreateSoundExpr(TonParser::CreateSoundExprContext 
             realPresetIndex = 0;
         }
 
-        float velocity = 0.8f;
         std::vector<float> floatSamples(totalSamples);
-        tsf_note_on(soundFont, realPresetIndex, note.toMidiNumber(), velocity);
+        tsf_note_on(soundFont, realPresetIndex, note.toMidiNumber(), volume);
         tsf_render_float(soundFont, floatSamples.data(), totalSamples, 0);
         tsf_note_off(soundFont, realPresetIndex, note.toMidiNumber());
 
@@ -598,6 +594,75 @@ std::any TonInterpreter::visitAudioOpStat(TonParser::AudioOpStatContext *ctx) {
         if (!found) throw std::runtime_error("Error: Alias '" + aliasName + "' not found on track.");
     }
 
+    if (ctx->MUTE()) {
+        if (targetNode->ID().size() != 2 || targetNode->STRING_VAL() != nullptr) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": The MUTE operation can only be applied to a TRACK.");
+        }
+        try {
+            timeline.tracks.at(trackName).isMuted = true;
+        } catch (std::out_of_range& ex) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": Given TRACK does not exist.");
+        }
+    }
+
+    if (ctx->UNMUTE()) {
+        if (targetNode->ID().size() != 2 || targetNode->STRING_VAL() != nullptr) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": The MUTE operation can only be applied to a TRACK.");
+        }
+        try {
+            timeline.tracks.at(trackName).isMuted = false;
+        } catch (std::out_of_range& ex) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": Given TRACK does not exist.");
+        }
+    }
+
+    if (ctx->VOL()) {
+        auto targetCtx = ctx->target();
+
+        if (targetCtx->ID().size() != 2 || targetCtx->STRING_VAL() != nullptr) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": The VOL operation can only be applied to a TRACK.");
+        }
+        std::any volAny = visit(ctx->expr());
+        float newVolume = 1.0f;
+
+        if (volAny.type() == typeid(int)) {
+            newVolume = static_cast<float>(std::any_cast<int>(volAny));
+        } else if (volAny.type() == typeid(double)) {
+            newVolume = static_cast<float>(std::any_cast<double>(volAny));
+        } else if (volAny.type() == typeid(float)) {
+            newVolume = std::any_cast<float>(volAny);
+        } else {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": Volume must be a number in range [0, 2].");
+        }
+
+        if (newVolume < 0.0f) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": Track volume must be positive. Given: " + std::to_string(newVolume));
+        }
+
+        std::string trackName = targetCtx->ID(1)->getText();
+        try {
+            auto& track = timeline.tracks.at(trackName);
+            track.volume = newVolume;
+        } catch(const std::out_of_range& ex) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": Given TRACK does not exist.");
+        }
+    }
     return {};
 }
 
@@ -752,27 +817,63 @@ std::any TonInterpreter::visitNumValExpr(TonParser::NumValExprContext *ctx) {
     return std::stod(ctx->NUM_VAL()->getText());
 }
 
-std::any TonInterpreter::visitMulDivExpr(TonParser::MulDivExprContext *ctx) {
-    std::any left = visit(ctx -> expr(0));
-    std::any right = visit(ctx -> expr(1));
-    
-    double leftVal =(left.type() == typeid(int)) ? std::any_cast<int>(left) : std::any_cast<double>(left);
-    double rightVal = (right.type() == typeid(int)) ? std::any_cast<int>(right) : std::any_cast<double>(right);
 
-    if (ctx-> MULT()){
-        if(left.type() == typeid(int) && right.type() == typeid(int)) return (int)(leftVal * rightVal);
+std::any TonInterpreter::visitMulDivExpr(TonParser::MulDivExprContext *ctx) {
+    std::any left = visit(ctx->expr(0));
+    std::any right = visit(ctx->expr(1));
+
+    if (ctx->MULT()) {
+        bool isLeftSound = (left.type() == typeid(Sound));
+        bool isRightSound = (right.type() == typeid(Sound));
+
+        if (isLeftSound || isRightSound) {
+            std::any numberAny = isLeftSound ? right : left;
+            
+            if (numberAny.type() == typeid(double) || numberAny.type() == typeid(int)) {
+                Sound s = isLeftSound ? std::any_cast<Sound>(left) : std::any_cast<Sound>(right);
+                double multiplier = (numberAny.type() == typeid(double)) 
+                    ? std::any_cast<double>(numberAny) 
+                    : static_cast<double>(std::any_cast<int>(numberAny));
+                return s * multiplier;
+            } 
+            else {
+                size_t line = ctx->getStart()->getLine();
+                throw std::runtime_error("Line " + std::to_string(line) + ": Error - SOUND can only be multiplied by INT or NUMERICAL.");
+            }
+        }
+
+        if ((left.type() != typeid(int) && left.type() != typeid(double)) ||
+            (right.type() != typeid(int) && right.type() != typeid(double))) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) + ": Error - Mathematical multiplication requires numbers.");
+        }
+
+        double leftVal = (left.type() == typeid(int)) ? std::any_cast<int>(left) : std::any_cast<double>(left);
+        double rightVal = (right.type() == typeid(int)) ? std::any_cast<int>(right) : std::any_cast<double>(right);
+
+        if (left.type() == typeid(int) && right.type() == typeid(int)) return (int)(leftVal * rightVal);
         return (leftVal * rightVal);   
     }
-    else if (ctx->DIV_OP()){
-        if (rightVal==0.0){
+    else if (ctx->DIV_OP()) {
+        if ((left.type() != typeid(int) && left.type() != typeid(double)) ||
+            (right.type() != typeid(int) && right.type() != typeid(double))) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) + ": Error - Mathematical division requires numbers.");
+        }
+
+        double leftVal = (left.type() == typeid(int)) ? std::any_cast<int>(left) : std::any_cast<double>(left);
+        double rightVal = (right.type() == typeid(int)) ? std::any_cast<int>(right) : std::any_cast<double>(right);
+
+        if (rightVal == 0.0) {
             throw std::runtime_error("Line " + std::to_string(ctx->getStart()->getLine()) + ": ERROR - Division by zero!");
         }
+        
         if (left.type() == typeid(int) && right.type() == typeid(int)) return (int)(leftVal / rightVal);
         return leftVal / rightVal;
     }
+    
     return {};
 }
-
 
 std::any TonInterpreter::visitAddSubMixExpr(TonParser::AddSubMixExprContext *ctx) {
     std::any left = visit(ctx->expr(0));
@@ -791,10 +892,10 @@ std::any TonInterpreter::visitAddSubMixExpr(TonParser::AddSubMixExprContext *ctx
             for (size_t i = 0; i < maxSize; ++i) {
                 double val1 = (i < s1.samples.size()) ? s1.samples[i] : 0.0;
                 double val2 = (i < s2.samples.size()) ? s2.samples[i] : 0.0;
-                // TODO for now tanh, normalizing later on!
-                mixedSound.samples.push_back(std::tanh(val1 + val2));
-                //mixedSound.samples.push_back(val1 + val2);
+                mixedSound.samples.push_back((val1 + val2));
+                
             }
+            std::cout << *std::max_element(mixedSound.samples.begin(), mixedSound.samples.end());
             return mixedSound;
         }
         

--- a/src/interpreter/TonInterpreter.cpp
+++ b/src/interpreter/TonInterpreter.cpp
@@ -2,6 +2,49 @@
 #include "interpreter/TonInterpreter.h"
 #include <cmath>
 
+#define TSF_IMPLEMENTATION
+#include "core/tsf.h"
+
+const std::unordered_map<std::string, int> TonInterpreter::SAMPLE_INSTRUMENTS = {
+    {"piano",      0}, // YAMAHA GRAND PIANO
+    {"organ",      19}, // CHURCH ORGAN
+    {"rock_organ", 18}, // ROCK ORGAN
+    {"guitar",     24}, // NYLON STRING GUITAR
+    {"overdrive",  29}, // OVERDRIVE GUITAR
+    {"bass",       33}, // Fingered Bass
+    {"violin",     40}, // Violin
+    {"cello",      42}, // Cello
+    {"contrabass", 43}, // Contrabass
+    {"strings",    48}, // Strings
+    {"trumpet",    56}, // Trumpet
+    {"flute",      73}, // Flute
+    {"drums",      116} // Taiko Drum
+};
+
+const std::unordered_set<std::string> TonInterpreter::SYNTHS = {
+    "sine"
+};
+
+TonInterpreter::TonInterpreter() : currentStackDepth{0} {
+    currentScope = std::make_shared<Scope<std::any>>();
+
+    soundFont = tsf_load_filename("data/FluidR3_GM.sf2");
+    if (!this->soundFont) {
+        std::cerr << "Could not load SoundFont from data/FluidR3_GM.sf2!" << std::endl;
+    } else {
+        tsf_set_output(soundFont, TSF_MONO, 44100, 0);
+    }
+
+    for (const std::string& synthName : SYNTHS) {
+        loadedInstruments.emplace(synthName, Instrument(synthName));
+    }
+}
+
+TonInterpreter::~TonInterpreter() {
+    if (this->soundFont != nullptr) {
+        tsf_close(this->soundFont);
+    }
+}
 
 std::any TonInterpreter::visitProgram(TonParser::ProgramContext *ctx) {
     return visitChildren(ctx);
@@ -89,6 +132,26 @@ std::any TonInterpreter::visitTargetExpr(TonParser::TargetExprContext *ctx) {
     }
 
     return timeline.tracks[trackName];
+}
+
+std::any TonInterpreter::visitHeader(TonParser::HeaderContext *ctx) {
+    std::string instrName = ctx->ID()->getText();
+
+    if (!soundFont) {
+        throw std::runtime_error("SoundFont library is not initialized!");
+    }
+
+    auto it = SAMPLE_INSTRUMENTS.find(instrName);
+
+    if (it != SAMPLE_INSTRUMENTS.end()) {
+        loadedInstruments.emplace(instrName, Instrument(instrName, it->second));
+    }
+    else {
+        size_t line = ctx->getStart()->getLine();
+        throw std::runtime_error("Line " + std::to_string(line) + ": Unknown standard instrument '" + instrName + "'.");
+    }
+
+    return {};
 }
 
 
@@ -234,7 +297,7 @@ std::any TonInterpreter::visitShoutStat(TonParser::ShoutStatContext *ctx) {
     }
     else if (value.type() == typeid(Instrument)) {
         Instrument currentInstrument = std::any_cast<Instrument>(value);
-        std::cout << "INSTRUMENT(" << currentInstrument.name << ")";
+        std::cout << "INSTRUMENT(" << currentInstrument.getName() << ")";
     }
     else if (value.type() == typeid(std::vector<std::any>)) {
         auto arrayElements = std::any_cast<std::vector<std::any>>(value);
@@ -285,7 +348,7 @@ std::any TonInterpreter::visitSaveStat(TonParser::SaveStatContext *ctx) {
 
     if (exportedValue.type() == typeid(Sound)) {
         Sound soundToSave = std::any_cast<Sound>(exportedValue);
-        AudioFile<double> audioFile;
+        AudioFile<float> audioFile;
         audioFile.setNumChannels(1);
         audioFile.setNumSamplesPerChannel(soundToSave.samples.size());
         audioFile.setSampleRate(soundToSave.sampleRate);
@@ -343,40 +406,57 @@ std::any TonInterpreter::visitSaveStat(TonParser::SaveStatContext *ctx) {
 
 
 std::any TonInterpreter::visitCreateSoundExpr(TonParser::CreateSoundExprContext *ctx) {
-    std::string instrumentOrSoundId = ctx->ID()->getText();
+    std::string soundId = ctx->ID()->getText();
     std::any arg1 = visit(ctx->expr(0));
     std::any arg2 = visit(ctx->expr(1));
 
-    Note note;
-    int durationMs;
+    Note note = std::any_cast<Note>(arg1);;
+    int durationMs = std::any_cast<int>(arg2);;
 
-    note = std::any_cast<Note>(arg1);
-    durationMs = std::any_cast<int>(arg2);
+    Sound generatedSound;
+    int totalSamples = (durationMs / 1000.0) * generatedSound.sampleRate;
+
+    auto it = loadedInstruments.find(soundId);
+
+    if (it == loadedInstruments.end()) {
+        size_t line = ctx->getStart()->getLine();
+        throw std::runtime_error("Line " + std::to_string(line) + ": Instrument or synth '"
+            + soundId + "' not found. Did you USE it?");
+    }
+
+    Instrument& instr = it->second;
 
     
-
-    note = std::any_cast<Note>(arg1);
-    durationMs = std::any_cast<int>(arg2);
-
-    
-    // TODO choose right sample instead of using temp lambda
-    // -----
-    auto createTemporarySinWave = [](Note note, int dur) {
-        Sound generatedSound;
-        int totalSamples = (dur / 1000.0) * generatedSound.sampleRate;
-        for (int i = 0; i < totalSamples; ++i) {
-            double time = (double)i / generatedSound.sampleRate;
-            double sampleValue = std::sin(2.0 * M_PI * note.getFrequency() * time);
-            generatedSound.samples.push_back(sampleValue);
+    if (instr.getType() == InstrumentType::Synth) {
+        try {
+            generatedSound.generateSynthWave(instr.getName(), note, durationMs);
         }
-        return generatedSound;
-    };
-    // ------
-    
-    Sound sound = createTemporarySinWave(note, durationMs);
+        catch(std::runtime_error& ex) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) + ": There is no synth named'"
+                                     + soundId + ".");
+        }
+    }
+    else if (instr.getType() == InstrumentType::SoundFont) {
+        std::cout << instr.getName();
+        if (!soundFont) throw std::runtime_error("SoundFont library is not initialized.");
+        int realPresetIndex = tsf_get_presetindex(soundFont, 0, instr.getMidiPresetIndex());
 
-    
-    return sound;
+        if (realPresetIndex < 0) {
+            std::cerr << ">>> [WARNING] MIDI Preset " << instr.getMidiPresetIndex() << " not found in SoundFont! Using default.\n";
+            realPresetIndex = 0;
+        }
+
+        float velocity = 0.8f;
+        std::vector<float> floatSamples(totalSamples);
+        tsf_note_on(soundFont, realPresetIndex, note.toMidiNumber(), velocity);
+        tsf_render_float(soundFont, floatSamples.data(), totalSamples, 0);
+        tsf_note_off(soundFont, realPresetIndex, note.toMidiNumber());
+
+        generatedSound.samples.assign(floatSamples.begin(), floatSamples.end());
+    }
+
+    return generatedSound;
 }
 
 std::any TonInterpreter::visitStringValExpr(TonParser::StringValExprContext *ctx) {
@@ -660,7 +740,6 @@ std::any TonInterpreter::visitAddSubMixExpr(TonParser::AddSubMixExprContext *ctx
             Sound s2 = std::any_cast<Sound>(right);
             
             Sound mixedSound;
-            mixedSound.sampleRate = s1.sampleRate; 
             
             size_t maxSize = std::max(s1.samples.size(), s2.samples.size());
             mixedSound.samples.reserve(maxSize);
@@ -707,7 +786,6 @@ std::any TonInterpreter::visitConcatExpr(TonParser::ConcatExprContext *ctx)
         Sound s2 = std::any_cast<Sound>(right);
         
         Sound concatSound;
-        concatSound.sampleRate = s1.sampleRate;
         
         concatSound.samples.reserve(s1.samples.size() + s2.samples.size());
         

--- a/src/interpreter/TonInterpreter.cpp
+++ b/src/interpreter/TonInterpreter.cpp
@@ -25,14 +25,58 @@ const std::unordered_set<std::string> TonInterpreter::SYNTHS = {
     "sine"
 };
 
+std::string TonInterpreter::findSoundFontPath() {
+    std::string fileName = "FluidR3_GM.sf2";
+
+    // 1. Env Path - optional
+    if (const char* envPath = std::getenv("TON_SOUNDFONT_PATH")) {
+        std::filesystem::path p(envPath);
+        if (std::filesystem::exists(p)) {
+            return p.string();
+        }
+    }
+
+    // possible directories
+    // for debug purposes when running Ton from ./{PROJECT_ROOT} or ./{PROJECT_ROOT}/build
+    std::vector<std::filesystem::path> possiblePaths = {
+        std::filesystem::path("data") / fileName,              // Terminal w głównym folderze
+        std::filesystem::path("..") / "data" / fileName,       // Terminal w folderze build/
+        std::filesystem::path("..") / ".." / "data" / fileName // Typowe dla IDE na Windowsie
+    };
+
+    // Fetching home directory
+    const char* homeDir = std::getenv("HOME"); // Linux / macOS
+    if (!homeDir) {
+        homeDir = std::getenv("USERPROFILE");  // Windows
+    }
+
+    if (homeDir) {
+        std::filesystem::path home(homeDir);
+        // Looking for file named FluidR3_GM.sf2 in $HOME/.ton/ directory
+        possiblePaths.push_back(home / ".ton" / fileName);
+    }
+
+    // One by one verification in created possible paths.
+    // searching order is: EnvPath ; debug directories ; $HOME/.ton
+    for (const auto& path : possiblePaths) {
+        if (std::filesystem::exists(path)) {
+            return path.string();
+        }
+    }
+
+    // Returning data/fileName if the file was not found.
+    return (std::filesystem::path("data") / fileName).string();
+}
+
 TonInterpreter::TonInterpreter() : currentStackDepth{0} {
     currentScope = std::make_shared<Scope<std::any>>();
 
-    soundFont = tsf_load_filename("data/FluidR3_GM.sf2");
+    std::string sfPath = findSoundFontPath();
+    soundFont = tsf_load_filename(sfPath.c_str());
     if (!this->soundFont) {
         std::cerr << "Could not load SoundFont from data/FluidR3_GM.sf2!" << std::endl;
     } else {
-        tsf_set_output(soundFont, TSF_MONO, 44100, 0);
+        tsf_set_output(soundFont, TSF_MONO, Sound::sampleRate, 0);
     }
 
     for (const std::string& synthName : SYNTHS) {

--- a/src/typechecker/TonTypeChecker.cpp
+++ b/src/typechecker/TonTypeChecker.cpp
@@ -55,6 +55,23 @@ std::any TonTypeChecker::visitMulDivExpr(TonParser::MulDivExprContext *ctx) {
     std::string left = std::any_cast<std::string>(visit(ctx->expr(0)));
     std::string right = std::any_cast<std::string>(visit(ctx->expr(1)));
 
+    if (left == "SOUND" || right == "SOUND") {
+        if (ctx->DIV_OP() != nullptr) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Type Error in line " + std::to_string(line) + 
+               ": Cannot divide a SOUND. Use multiplication with fractions (e.g. SOUND * 0.5) instead.");
+        }
+        if (left == "SOUND" && (right == "INT" || right == "NUMERICAL")) {
+            return std::string("SOUND");
+        }
+        if (right == "SOUND" && (left == "INT" || left == "NUMERICAL")) {
+            return std::string("SOUND");
+        }
+        size_t line = ctx->getStart()->getLine();
+        throw std::runtime_error("Type Error in line " + std::to_string(line) + 
+            ": A SOUND can only be multiplied by an INT or NUMERICAL.");
+    }
+    
     if ((left == "INT" || left == "NUMERICAL") && (right == "INT" || right == "NUMERICAL")) {
         return (left == "NUMERICAL" || right == "NUMERICAL") ? std::string("NUMERICAL") : std::string("INT");
     }
@@ -115,7 +132,7 @@ std::any TonTypeChecker::visitFunctionCallExpr(TonParser::FunctionCallExprContex
 
     if (!currentScope->exists(funcName)) {
         size_t line = ctx->getStart()->getLine();
-        throw std::runtime_error("Error in line " + std::to_string(line) + 
+        throw std::runtime_error("Line " + std::to_string(line) +
                                  ": Function '" + funcName + "' is not defined.");
     }
     std::string returnType = currentScope->resolveType(funcName);
@@ -128,14 +145,24 @@ std::any TonTypeChecker::visitCreateSoundExpr(TonParser::CreateSoundExprContext 
 
     if (arg1Type != "NOTE") {
         size_t line = ctx->getStart()->getLine();
-        throw std::runtime_error("Type Error in line " + std::to_string(line) + 
+        throw std::runtime_error("Line " + std::to_string(line) +
                                  ": First argument of CreateSound must be a NOTE. Given: " + arg1Type);
     }
     
     if (arg2Type != "INT") {
         size_t line = ctx->getStart()->getLine();
-        throw std::runtime_error("Type Error in line " + std::to_string(line) + 
+        throw std::runtime_error("Line " + std::to_string(line) +
                                  ": Second argument (duration) of CreateSound must be an INT. Given: " + arg2Type);
+    }
+
+    if (ctx->expr().size() > 2) {
+        std::string arg3Type = std::any_cast<std::string>(visit(ctx->expr(2)));
+
+        if (arg3Type != "INT" && arg3Type != "NUMERICAL") {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Line " + std::to_string(line) +
+                                     ": Third argument (volume) of SOUND must be INT or NUMERICAL. Given: " + arg3Type);
+        }
     }
     return std::string("SOUND");
 }


### PR DESCRIPTION
been a while since last major update, huh?

1. `FluidR3_GM.sf2` file now automatically loads in `TonInterpreter` constructor. Idealy, it should be stored in `$HOME/.ton/` directory but it should also find it in `${PROJECT_ROOT}/data` if you are running ton from project root directory. Paths also work on Windows, but obviously I did not check that, so feel free to issue this if something will not work as intended.
2. Language supports `USE instr_name` construction
3. Available instruments can be viewed in the beginning of `TonInterpreter.cpp` file, as they are stored in `TonInterpreter::SAMPLE_INSTRUMENTS` static variable.
4. Ton finally evaluates instrument type in createSoundExpr. Beside samples, you still can use synthetic generators. For now only `sine` is implemented. Synthetizers implementations have their place in `Sound` class as this one creates soounds.
5. Three ways of manipulating `SOUND` volumes implemented (as discussed in #34 ). 
6. `MUTE` operator has been fixed - its now working properly.
7. When visiting `SAVE` expr TimeLine is being rendered into final `SOUND` object and thevolume is normalized to the proper scale [0,1].

Think, thats all, I would apprietiate some feedback since there is muuch new code.
Also, docs need an update on this one, its already mentioned in docs/brainstorm.md, we will have to write it down properly someday :(

Happy Tøning boys!!! :rocket: 