### PR TITLE
implement parent:: operator across interpreter, typechecker, and list…

### DIFF
--- a/Ton.g4
+++ b/Ton.g4
@@ -28,10 +28,12 @@ statement
 
 varDecl : EXCLAM_MARK MAKE type ID (ASSIGN expr)? SEMI ;
 
-trackDecl : ID NEW TRACK ID SEMI ;
+trackDecl : target NEW TRACK ID SEMI ;
 
 // Target żeby się dało: adresowanie wielopoziomowe: ID, ID.ID, lub ID.ID."alias"
-target : ID (DOT ID (DOT STRING_VAL)?)? ;
+target : parentRef* ID (DOT ID (DOT STRING_VAL)?)? ;
+
+parentRef : PARENT DOUBLE_COLON ;
 
 // Zeby sie dalo wywolac funkcje void
 callStat : ID L_PAREN (expr (COMMA expr)*)? R_PAREN SEMI ;
@@ -78,8 +80,8 @@ audioOpStat
 
 
 arrayOpStat
-    : APPEND expr TO ID SEMI
-    | CLEAR ID SEMI
+    : APPEND expr TO target SEMI
+    | CLEAR target SEMI
     ;
 
 saveStat : EXCLAM_MARK SAVE expr STRING_VAL SEMI ;
@@ -117,7 +119,7 @@ expr
     | LENGTH target                                            # LengthOfExpr 
     | EMPTYSOUND                                               # EmptySoundExpr   
     | ISOLATE target                                           # IsolateExpr  
-    | POP ID                                                   # PopExpr                      
+    | POP target                                               # PopExpr                      
     ;
 
 // --- TOKENS ---
@@ -170,6 +172,10 @@ DIVIDE         : 'DIVIDE' ;
 EMPTYSOUND     : 'EMPTYSOUND' ;
 VOL            : 'VOL' ;
 
+// --- Najpierw tokeny dwuznakowe / specjalne dla parent ---
+PARENT         : 'parent' ;
+DOUBLE_COLON   : '::' ;
+
 ASSIGN         : '<-' ; 
 ADD_ASSIGN     : '+<-' ;
 SUB_ASSIGN     : '-<-' ;
@@ -216,3 +222,4 @@ POP            : 'POP' ;
 ID             : [a-zA-Z_][a-zA-Z0-9_]* ;
 WS             : [ \t\r\n]+ -> skip ;
 COMMENT        : '$' ~[\r\n]* -> skip ;
+

--- a/Ton.g4
+++ b/Ton.g4
@@ -31,9 +31,9 @@ varDecl : EXCLAM_MARK MAKE type ID (ASSIGN expr)? SEMI ;
 trackDecl : target NEW TRACK ID SEMI ;
 
 // Target żeby się dało: adresowanie wielopoziomowe: ID, ID.ID, lub ID.ID."alias"
-target : parentRef* ID (DOT ID (DOT STRING_VAL)?)? ;
+target : elderRef* ID (DOT ID (DOT STRING_VAL)?)? ;
 
-parentRef : PARENT DOUBLE_COLON ;
+elderRef : ELDER DOUBLE_COLON ;
 
 // Zeby sie dalo wywolac funkcje void
 callStat : ID L_PAREN (expr (COMMA expr)*)? R_PAREN SEMI ;
@@ -173,7 +173,7 @@ EMPTYSOUND     : 'EMPTYSOUND' ;
 VOL            : 'VOL' ;
 
 // --- Najpierw tokeny dwuznakowe / specjalne dla parent ---
-PARENT         : 'parent' ;
+ELDER         : 'ELDER' ;
 DOUBLE_COLON   : '::' ;
 
 ASSIGN         : '<-' ; 

--- a/examples/error_examples/errorexample_elder.txt
+++ b/examples/error_examples/errorexample_elder.txt
@@ -1,0 +1,44 @@
+$ ==============================================================
+$ SKRYPT TESTOWY: EDGE CASE'Y OPERATORA ELDER::
+$ UWAGA: Odkomentowuj testy POJEDYNCZO, bo Listener przerywa dzialanie po pierwszym bledzie!
+$ ==============================================================
+
+!make INT global_x <- 10;
+!make ARRAY global_arr <- [1, 2];
+
+{
+    !make STRING global_x <- "napis lokalny";
+    !make INT b <- 99;
+    
+    $ -------------------------------------------------------------
+    $ TEST 1: Wspinaczka zbyt wysoko (Edge Case)
+    $ Chcemy się odwołać do ELDER::ELDER, ale jesteśmy tylko 1 poziom głęboko.
+    $ Oczekiwany błąd: "...reached beyond global scope."
+    $ -------------------------------------------------------------
+    $ ELDER::ELDER::global_x <- 50;
+
+
+    $ -------------------------------------------------------------
+    $ TEST 2: Niezgodność typów na wyższym poziomie (Edge Case wyłapany przez Ownera)
+    $ Lokalnie 'global_x' to STRING, ale ELDER::global_x to INT.
+    $ Próbujemy przypisać STRINGA do INTa w rodzicu.
+    $ Oczekiwany błąd: "Cannot assign STRING to variable 'global_x' of type INT"
+    $ -------------------------------------------------------------
+    $ ELDER::global_x <- "To zepsuje TypeChecker";
+
+
+    $ -------------------------------------------------------------
+    $ TEST 3: Odwołanie do zmiennej, która wyżej nie istnieje (Edge Case)
+    $ Zmienna 'b' istnieje tylko w tym lokalnym bloku, nie ma jej u ELDERA.
+    $ Oczekiwany błąd: "Variable 'b' is not defined."
+    $ -------------------------------------------------------------
+    $ ELDER::b <- 100;
+
+
+    $ -------------------------------------------------------------
+    $ TEST 4: Próba operacji na złym typie w rodzicu (Edge Case)
+    $ Próbujemy wykonać komendę tablicową na zmiennej globalnej, która jest INT.
+    $ Oczekiwany błąd: "Cannot perform array operations on type INT."
+    $ -------------------------------------------------------------
+    $ APPEND 5 TO ELDER::global_x;
+}

--- a/examples/example_others/example_parent.ton
+++ b/examples/example_others/example_parent.ton
@@ -1,0 +1,47 @@
+$ ==============================================================
+$ SOLIDNY TEST OPERATORA PARENT:: (ISSUE #81)
+$ ==============================================================
+
+!make INT var_x <- 10;
+!make STRING tekst <- "Globalny";
+!make ARRAY tablica <- [1, 2, 3];
+
+!shout "[POZIOM 0] Start: var_x = ", var_x, ", tekst = ", tekst;
+
+{
+    $ Przesłaniemy zmienne lokalnie (Shadowing)
+    !make INT var_x <- 50;
+    !make STRING tekst <- "Lokalny_Poziom_1";
+    
+    $ TEST 1: Nadpisanie wartości w scope nadrzędnym (visitAssignment)
+    parent::var_x <- 100;
+    parent::tekst <- "Zmieniony_Przez_Rodzica";
+    
+    $ TEST 2: Odczyt z nadrzędnego scope'u przy przesłoniętych nazwach (visitTargetExpr)
+    !shout "[POZIOM 1] Lokalny var_x = ", var_x;
+    !shout "[POZIOM 1] Nadrzedny parent::var_x = ", parent::var_x;
+    !shout "[POZIOM 1] Nadrzedny parent::tekst = ", parent::tekst;
+    
+    {
+        $ Wchodzimy o krok głębiej - dwa poziomy zagnieżdżenia bloku
+        !make INT var_x <- 999;
+        
+        $ TEST 3: Wspinaczka wielopoziomowa (parent::parent::)
+        $ Modyfikujemy zmienną na samym szczycie (z 100 na 777)
+        parent::parent::var_x <- 777;
+        
+        $ TEST 4: Operacje na tablicy z najwyższego poziomu
+        $ Sprawdzamy czy resolveScope() działa dla innych typów komend
+        APPEND 4 TO parent::parent::tablica;
+        
+        !shout "[POZIOM 2] Zagniezdzony var_x = ", var_x;
+        !shout "[POZIOM 2] Srodkowy parent::var_x = ", parent::var_x;
+        !shout "[POZIOM 2] Najwyzszy parent::parent::var_x = ", parent::parent::var_x;
+        !shout "[POZIOM 2] Najwyzsza parent::parent::tablica = ", parent::parent::tablica;
+    }
+}
+
+!shout "--------------------------------------------------";
+!shout "[POZIOM 0] Wynik var_x (Powinien byc 777): ", var_x;
+!shout "[POZIOM 0] Wynik tekst: ", tekst;
+!shout "[POZIOM 0] Wynik tablica (Powinna miec [1, 2, 3, 4]): ", tablica;

--- a/examples/example_others/example_parent.ton
+++ b/examples/example_others/example_parent.ton
@@ -1,5 +1,5 @@
 $ ==============================================================
-$ SOLIDNY TEST OPERATORA PARENT:: (ISSUE #81)
+$ SOLIDNY TEST OPERATORA ELDER:: (ISSUE #81)
 $ ==============================================================
 
 !make INT var_x <- 10;
@@ -14,30 +14,30 @@ $ ==============================================================
     !make STRING tekst <- "Lokalny_Poziom_1";
     
     $ TEST 1: Nadpisanie wartości w scope nadrzędnym (visitAssignment)
-    parent::var_x <- 100;
-    parent::tekst <- "Zmieniony_Przez_Rodzica";
+    ELDER::var_x <- 100;
+    ELDER::tekst <- "Zmieniony_Przez_Rodzica";
     
     $ TEST 2: Odczyt z nadrzędnego scope'u przy przesłoniętych nazwach (visitTargetExpr)
     !shout "[POZIOM 1] Lokalny var_x = ", var_x;
-    !shout "[POZIOM 1] Nadrzedny parent::var_x = ", parent::var_x;
-    !shout "[POZIOM 1] Nadrzedny parent::tekst = ", parent::tekst;
+    !shout "[POZIOM 1] Nadrzedny ELDER::var_x = ", ELDER::var_x;
+    !shout "[POZIOM 1] Nadrzedny ELDER::tekst = ", ELDER::tekst;
     
     {
         $ Wchodzimy o krok głębiej - dwa poziomy zagnieżdżenia bloku
         !make INT var_x <- 999;
         
-        $ TEST 3: Wspinaczka wielopoziomowa (parent::parent::)
+        $ TEST 3: Wspinaczka wielopoziomowa (ELDER::ELDER::)
         $ Modyfikujemy zmienną na samym szczycie (z 100 na 777)
-        parent::parent::var_x <- 777;
+        ELDER::ELDER::var_x <- 777;
         
         $ TEST 4: Operacje na tablicy z najwyższego poziomu
         $ Sprawdzamy czy resolveScope() działa dla innych typów komend
-        APPEND 4 TO parent::parent::tablica;
+        APPEND 4 TO ELDER::ELDER::tablica;
         
         !shout "[POZIOM 2] Zagniezdzony var_x = ", var_x;
-        !shout "[POZIOM 2] Srodkowy parent::var_x = ", parent::var_x;
-        !shout "[POZIOM 2] Najwyzszy parent::parent::var_x = ", parent::parent::var_x;
-        !shout "[POZIOM 2] Najwyzsza parent::parent::tablica = ", parent::parent::tablica;
+        !shout "[POZIOM 2] Srodkowy ELDER::var_x = ", ELDER::var_x;
+        !shout "[POZIOM 2] Najwyzszy ELDER::ELDER::var_x = ", ELDER::ELDER::var_x;
+        !shout "[POZIOM 2] Najwyzsza ELDER::ELDER::tablica = ", ELDER::ELDER::tablica;
     }
 }
 

--- a/include/interpreter/TonInterpreter.h
+++ b/include/interpreter/TonInterpreter.h
@@ -40,6 +40,9 @@ private:
     std::any executeFunctionLogic(const std:: string& funcName, const std::vector<TonParser::ExprContext*>& argsCtx);
     void validateStackDepth();
 
+    std::shared_ptr<Scope<std::any>> resolveScope(TonParser::TargetContext *ctx);
+    
+
 public:
     TonInterpreter();
     ~TonInterpreter();

--- a/include/typechecker/TonTypeChecker.h
+++ b/include/typechecker/TonTypeChecker.h
@@ -53,4 +53,6 @@ public:
     std::any visitIsolateExpr(TonParser::IsolateExprContext *ctx) override;
 
     std::any visitPopExpr(TonParser::PopExprContext *ctx) override;
+
+    std::any visitArrayOpStat(TonParser::ArrayOpStatContext *ctx) override;
 };

--- a/src/interpreter/TonInterpreter.cpp
+++ b/src/interpreter/TonInterpreter.cpp
@@ -25,6 +25,21 @@ const std::unordered_set<std::string> TonInterpreter::SYNTHS = {
     "sine"
 };
 
+
+std::shared_ptr<Scope<std::any>> TonInterpreter::resolveScope(TonParser::TargetContext *ctx) {
+    int parentCount = ctx->parentRef().size();
+    auto targetScope = currentScope;
+    
+    for (int i = 0; i < parentCount; ++i) {
+        if (targetScope->parent == nullptr) {
+            size_t line = ctx->getStart()->getLine();
+            throw std::runtime_error("Error in line " + std::to_string(line) + ": 'parent::' reached beyond global scope.");
+        }
+        targetScope = targetScope->parent;
+    }
+    return targetScope;
+}
+
 std::string TonInterpreter::findSoundFontPath() {
     std::string fileName = "FluidR3_GM.sf2";
 
@@ -153,22 +168,23 @@ std::any TonInterpreter::visitVarDecl(TonParser::VarDeclContext *ctx) {
 
 
 std::any TonInterpreter::visitTargetExpr(TonParser::TargetExprContext *ctx) {
-
     auto targetNode = ctx->target(); 
     std::string baseName = targetNode->ID(0)->getText();
 
-    if (!currentScope->exists(baseName)) {
+    auto targetScope = resolveScope(targetNode);
+
+    if (!targetScope->exists(baseName)) {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Error in line " + std::to_string(line) + ": Undefined variable or timeline '" + baseName + "'.");
     }
 
     if (targetNode->ID().size() == 1) {
-        return currentScope->get(baseName);
+        return targetScope->get(baseName);
     }
 
     std::string trackName = targetNode->ID(1)->getText();
     
-    std::any baseObj = currentScope->get(baseName);
+    std::any baseObj = targetScope->get(baseName);
     if (baseObj.type() != typeid(Timeline)) {
         throw std::runtime_error("Error: '" + baseName + "' is not a TIMELINE, cannot access tracks.");
     }
@@ -181,8 +197,7 @@ std::any TonInterpreter::visitTargetExpr(TonParser::TargetExprContext *ctx) {
 
     if (targetNode->STRING_VAL()) {
         std::string rawAlias = targetNode->STRING_VAL()->getText();
-        std::string aliasName = rawAlias.substr(1, rawAlias.length() - 2); // usuwamy " "
-
+        std::string aliasName = rawAlias.substr(1, rawAlias.length() - 2); 
 
         for (const auto& event : timeline.tracks[trackName].events) {
             if (event.alias == aliasName) {
@@ -190,13 +205,14 @@ std::any TonInterpreter::visitTargetExpr(TonParser::TargetExprContext *ctx) {
             }
         }
         
-    
         throw std::runtime_error("Error: Event alias '" + aliasName + "' does not exist in track '" + trackName + "'.");
-        
     }
 
     return timeline.tracks[trackName];
 }
+
+
+
 
 std::any TonInterpreter::visitHeader(TonParser::HeaderContext *ctx) {
     std::string instrName = ctx->ID()->getText();
@@ -225,27 +241,28 @@ std::any TonInterpreter::visitHeader(TonParser::HeaderContext *ctx) {
 std::any TonInterpreter::visitAssignment(TonParser::AssignmentContext *ctx) {
     auto targetNode = ctx->target();
 
+    auto targetScope = resolveScope(targetNode);
+
     if (targetNode->ID().size() == 1) {
         std::string varName = targetNode->ID(0)->getText();
-        if (!currentScope->exists(varName)) {
+        if (!targetScope->exists(varName)) {
             throw std::runtime_error("Error: Variable '" + varName + "' must be declared first.");
         }
-        currentScope->set(varName, visit(ctx->expr()));
+        targetScope->set(varName, visit(ctx->expr()));
         return {};
     }
 
     std::string timelineName = targetNode->ID(0)->getText();
     std::string trackName = targetNode->ID(1)->getText();
 
-    if (!currentScope->exists(timelineName)) throw std::runtime_error("Timeline not found");
+    if (!targetScope->exists(timelineName)) throw std::runtime_error("Timeline not found");
     
-    std::any& baseObj = currentScope->get(timelineName);
+    std::any& baseObj = targetScope->get(timelineName);
     Timeline& timeline = std::any_cast<Timeline&>(baseObj);
 
     if (timeline.tracks.find(trackName) == timeline.tracks.end()) throw std::runtime_error("Track not found");
 
     std::any rightSide = visit(ctx->expr());
-
 
     if (targetNode->STRING_VAL()) {
         std::string rawAlias = targetNode->STRING_VAL()->getText();
@@ -538,19 +555,18 @@ std::any TonInterpreter::visitIntValExpr(TonParser::IntValExprContext *ctx) {
 }
 
 
-
 std::any TonInterpreter::visitTrackDecl(TonParser::TrackDeclContext *ctx) {
+    auto targetNode = ctx->target();
+    std::string timelineName = targetNode->ID(0)->getText(); 
+    std::string trackName = ctx->ID()->getText(); // Pobiera czyste ID (nazwę tracku) z reguły
 
-    std::string timelineName = ctx->ID(0)->getText(); 
-    std::string trackName = ctx->ID(1)->getText();    
+    auto targetScope = resolveScope(targetNode);
 
-
-    if (!currentScope->exists(timelineName)) {
+    if (!targetScope->exists(timelineName)) {
         throw std::runtime_error("Error: Timeline '" + timelineName + "' not found.");
     }
 
-
-    std::any& baseObj = currentScope->get(timelineName);
+    std::any& baseObj = targetScope->get(timelineName);
     if (baseObj.type() != typeid(Timeline)) {
         throw std::runtime_error("Error: '" + timelineName + "' is not a TIMELINE.");
     }
@@ -569,19 +585,18 @@ std::any TonInterpreter::visitTrackDecl(TonParser::TrackDeclContext *ctx) {
 }
 
 
-
 std::any TonInterpreter::visitAudioOpStat(TonParser::AudioOpStatContext *ctx) {
     auto targetNode = ctx->target();
     std::string timelineName = targetNode->ID(0)->getText();
 
+    auto targetScope = resolveScope(targetNode);
 
-    if (!currentScope->exists(timelineName)) {
+    if (!targetScope->exists(timelineName)) {
         throw std::runtime_error("Error: Timeline '" + timelineName + "' not found.");
     }
-    std::any& baseObj = currentScope->get(timelineName);
+    std::any& baseObj = targetScope->get(timelineName);
     if (baseObj.type() != typeid(Timeline)) throw std::runtime_error("Error: Target is not a TIMELINE.");
     Timeline& timeline = std::any_cast<Timeline&>(baseObj);
-
 
     std::string trackName = "";
     if (targetNode->ID().size() > 1) {
@@ -594,9 +609,8 @@ std::any TonInterpreter::visitAudioOpStat(TonParser::AudioOpStatContext *ctx) {
     std::string aliasName = "";
     if (targetNode->STRING_VAL()) {
         std::string rawAlias = targetNode->STRING_VAL()->getText();
-        aliasName = rawAlias.substr(1, rawAlias.length() - 2); // usuwamy " "
+        aliasName = rawAlias.substr(1, rawAlias.length() - 2); 
     }
-
 
     if (ctx->SHIFT()) {
         if (trackName.empty() || aliasName.empty()) {
@@ -673,7 +687,6 @@ std::any TonInterpreter::visitAudioOpStat(TonParser::AudioOpStatContext *ctx) {
                                      ": Track volume must be positive. Given: " + std::to_string(newVolume));
         }
 
-        std::string trackName = targetCtx->ID(1)->getText();
         try {
             auto& track = timeline.tracks.at(trackName);
             track.volume = newVolume;
@@ -686,14 +699,19 @@ std::any TonInterpreter::visitAudioOpStat(TonParser::AudioOpStatContext *ctx) {
     return {};
 }
 
+
 std::any TonInterpreter::visitIsolateExpr(TonParser::IsolateExprContext *ctx) {
     auto targetNode = ctx -> target();
     std::string timelineName = targetNode->ID(0)->getText();
-    if (!currentScope->exists(timelineName)){
+
+    // WDROŻENIE WZORCA DRY:
+    auto targetScope = resolveScope(targetNode);
+
+    if (!targetScope->exists(timelineName)){
         throw std::runtime_error("Error: Timeline '" + timelineName + "' not found.");
     }
 
-    std::any& baseObj = currentScope->get(timelineName);
+    std::any& baseObj = targetScope->get(timelineName);
     if (baseObj.type() != typeid(Timeline)){
         throw std::runtime_error("Error: Target is not a TIMELINE.");
     }
@@ -1311,14 +1329,17 @@ std::any TonInterpreter::visitSliceExpr(TonParser::SliceExprContext *ctx) {
 
 
 std::any TonInterpreter::visitArrayOpStat(TonParser::ArrayOpStatContext *ctx) {
-    std::string varName = ctx->ID()->getText(); 
+    auto targetNode = ctx->target(); 
+    std::string varName = targetNode->ID(0)->getText(); 
 
-    if (!currentScope->exists(varName)) {
+    auto targetScope = resolveScope(targetNode);
+
+    if (!targetScope->exists(varName)) {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Line " + std::to_string(line) + ": Error - Array '" + varName + "' not found.");
     }
 
-    std::any arrayVal = currentScope->get(varName);
+    std::any arrayVal = targetScope->get(varName);
     
     if (arrayVal.type() != typeid(std::vector<std::any>)) {
         size_t line = ctx->getStart()->getLine();
@@ -1335,20 +1356,23 @@ std::any TonInterpreter::visitArrayOpStat(TonParser::ArrayOpStatContext *ctx) {
         vec.clear();
     }
 
-    currentScope->set(varName, vec);
+    targetScope->set(varName, vec);
     return {};
 }
 
 
 std::any TonInterpreter::visitPopExpr(TonParser::PopExprContext *ctx) {
-    std::string varName = ctx->ID()->getText(); // Czyste ID!
+    auto targetNode = ctx->target(); 
+    std::string varName = targetNode->ID(0)->getText();
 
-    if (!currentScope->exists(varName)) {
+    auto targetScope = resolveScope(targetNode);
+
+    if (!targetScope->exists(varName)) {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Line " + std::to_string(line) + ": Error - Array '" + varName + "' not found.");
     }
 
-    std::any arrayVal = currentScope->get(varName);
+    std::any arrayVal = targetScope->get(varName);
     
     if (arrayVal.type() != typeid(std::vector<std::any>)) {
         size_t line = ctx->getStart()->getLine();
@@ -1365,7 +1389,7 @@ std::any TonInterpreter::visitPopExpr(TonParser::PopExprContext *ctx) {
     std::any poppedItem = vec.back();
     vec.pop_back();
 
-    currentScope->set(varName, vec);
+    targetScope->set(varName, vec);
     
     return poppedItem;
 }

--- a/src/interpreter/TonInterpreter.cpp
+++ b/src/interpreter/TonInterpreter.cpp
@@ -27,7 +27,7 @@ const std::unordered_set<std::string> TonInterpreter::SYNTHS = {
 
 
 std::shared_ptr<Scope<std::any>> TonInterpreter::resolveScope(TonParser::TargetContext *ctx) {
-    int parentCount = ctx->parentRef().size();
+    int parentCount = ctx->elderRef().size();
     auto targetScope = currentScope;
     
     for (int i = 0; i < parentCount; ++i) {
@@ -558,7 +558,7 @@ std::any TonInterpreter::visitIntValExpr(TonParser::IntValExprContext *ctx) {
 std::any TonInterpreter::visitTrackDecl(TonParser::TrackDeclContext *ctx) {
     auto targetNode = ctx->target();
     std::string timelineName = targetNode->ID(0)->getText(); 
-    std::string trackName = ctx->ID()->getText(); // Pobiera czyste ID (nazwę tracku) z reguły
+    std::string trackName = ctx->ID()->getText();
 
     auto targetScope = resolveScope(targetNode);
 
@@ -704,7 +704,6 @@ std::any TonInterpreter::visitIsolateExpr(TonParser::IsolateExprContext *ctx) {
     auto targetNode = ctx -> target();
     std::string timelineName = targetNode->ID(0)->getText();
 
-    // WDROŻENIE WZORCA DRY:
     auto targetScope = resolveScope(targetNode);
 
     if (!targetScope->exists(timelineName)){

--- a/src/listener/TonDeclarationListener.cpp
+++ b/src/listener/TonDeclarationListener.cpp
@@ -3,6 +3,19 @@
 #include <string>
 #include <stdexcept>
 
+static std::shared_ptr<Scope<int>> resolveElderScope(std::shared_ptr<Scope<int>> currentScope, int elderCount, size_t line) {
+    auto targetScope = currentScope;
+    for (int i = 0; i < elderCount; ++i) {
+        if (targetScope->parent != nullptr) {
+            targetScope = targetScope->parent;
+        } else {
+            throw std::runtime_error("Error in line " + std::to_string(line) + ": 'ELDER::' reached beyond global scope.");
+        }
+    }
+    return targetScope;
+}
+
+
 void TonDeclarationListener::enterVarDecl(TonParser::VarDeclContext *ctx){
     std::string varName = ctx->ID()->getText();
     std::string typeName = ctx->type()->getText();
@@ -35,65 +48,67 @@ void TonDeclarationListener::exitVarDecl(TonParser::VarDeclContext *ctx) {
 }
 
 void TonDeclarationListener::enterTrackDecl(TonParser::TrackDeclContext *ctx){
+    int elderCount = ctx->target() -> elderRef().size();
+    auto targetScope = resolveElderScope(currentScope, elderCount, ctx->getStart()->getLine());  
+    
     std::string timelineName = ctx->target()->ID(0)->getText(); 
     std::string trackName = ctx->ID()->getText(); 
 
     int currentLine = ctx->getStart()->getLine();
-    if (currentScope->existsLocally(trackName)) {
-        int previousLine = currentScope->get(trackName);
-        
+    if (targetScope->existsLocally(trackName)) { 
+        int previousLine = targetScope->get(trackName); 
+
         throw std::runtime_error("Error in line " + std::to_string(currentLine) + 
                                  ": Variable redeclaration '" + trackName + 
                                  "'. Previous declaration is on line " + std::to_string(previousLine) + ".");
     }
 
-    currentScope->define(trackName, "TRACK", currentLine);
+    targetScope->define(trackName, "TRACK", currentLine); 
 }
 
 void TonDeclarationListener::exitAssignment(TonParser::AssignmentContext *ctx) {
     auto targetNode = ctx->target();
     std::string varName = targetNode->ID(0)->getText();
 
-    if (!currentScope->exists(varName)) {
+    int elderCount = targetNode->elderRef().size();
+    auto targetScope = resolveElderScope(currentScope, elderCount, ctx->getStart()->getLine());
+
+    if (!targetScope->exists(varName)) { 
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Error in line " + std::to_string(line) +
                                  ": Cannot assign to undefined variable '" + varName + "'.");
     }
-    // std::string expectedType = currentScope->resolveType(varName);
-    TonTypeChecker typeChecker(currentScope);
+    
+    TonTypeChecker typeChecker(currentScope); 
     std::any result = typeChecker.visit(ctx->expr());
     std::string actualType = std::any_cast<std::string>(result);
 
-    // --- SCENARIUSZ A: Zwykłe przypisanie (np. tempo <- 120) ---
+    // --- SCENARIUSZ A: Zwykłe przypisanie ---
     if (targetNode->ID().size() == 1) {
-        std::string expectedType = currentScope->resolveType(varName);
+        std::string expectedType = targetScope->resolveType(varName); 
         if (expectedType != actualType && actualType != "UNKNOWN") {
             size_t line = ctx->getStart()->getLine();
             throw std::runtime_error("Type Error in line " + std::to_string(line) +
                                      ": Cannot assign " + actualType + " to variable '" + varName + "' of type " + expectedType + ".");
         }
-        return; // Zwykłe przypisanie pomyślne!
+        return; 
     }
 
-    // --- SCENARIUSZ B: Przypisanie do tracka w TIMELINE (np. mySong.bassline <- ...) ---
-    std::string expectedBaseType = currentScope->resolveType(varName);
+    // --- SCENARIUSZ B: Przypisanie do tracka w TIMELINE ---
+    std::string expectedBaseType = targetScope->resolveType(varName); 
     if (expectedBaseType != "TIMELINE" ) {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Type Error in line " + std::to_string(line) +
                                  ": '" + varName + "' is not a TIMELINE.");
     }
 
-    // SCENARIUSZ B1: Przypisanie do konkretnego aliasu (mySong.bassline."start" <- beep)
     if (targetNode->STRING_VAL()) {
         if (actualType != "SOUND" && actualType != "TRACK_EVENT" && actualType != "UNKNOWN") {
             size_t line = ctx->getStart()->getLine();
             throw std::runtime_error("Type Error in line " + std::to_string(line) +
                                      ": Can only assign SOUND or TRACK_EVENT to a specific alias. Given: " + actualType);
         }
-    }
-
-    // SCENARIUSZ B2: Całościowe przypisanie na ścieżkę (mySong.bassline <- [bass AT 0])
-    else {
+    } else {
         if (actualType != "ARRAY" && actualType != "TRACK_EVENT" && actualType != "UNKNOWN") {
             size_t line = ctx->getStart()->getLine();
             throw std::runtime_error("Type Error in line " + std::to_string(line) +
@@ -105,7 +120,10 @@ void TonDeclarationListener::exitAssignment(TonParser::AssignmentContext *ctx) {
 void TonDeclarationListener::exitTargetExpr(TonParser::TargetExprContext *ctx) {
     std::string varName = ctx->target()->ID(0)->getText();
 
-    if (!currentScope->exists(varName)) {
+    int elderCount = ctx->target()->elderRef().size();
+    auto targetScope = resolveElderScope(currentScope, elderCount, ctx->getStart()->getLine());
+
+    if (!targetScope->exists(varName)) { 
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Error in line " + std::to_string(line) +
                                  ": Variable '" + varName + "' is not defined.");
@@ -182,27 +200,25 @@ void TonDeclarationListener::exitLoopStat(TonParser::LoopStatContext *ctx) {
 }
 
 void TonDeclarationListener::exitArrayOpStat(TonParser::ArrayOpStatContext *ctx) {
-
     std::string varName = ctx->target()->ID(0)->getText();
+    int elderCount = ctx->target()->elderRef().size();
+    auto targetScope = resolveElderScope(currentScope, elderCount, ctx->getStart()->getLine());
 
-    if (!currentScope->exists(varName)) {
+    if (!targetScope->exists(varName)) { 
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Error in line " + std::to_string(line) +
                                  ": Variable '" + varName + "' is not defined.");
     }
 
-    std::string targetType = currentScope->resolveType(varName);
+    std::string targetType = targetScope->resolveType(varName); 
     if (targetType != "ARRAY") {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Type Error in line " + std::to_string(line) +
                                  ": Cannot perform array operations on type " + targetType + ".");
     }
-
     
     if (ctx->APPEND()) {
-        TonTypeChecker typeChecker(currentScope);
+        TonTypeChecker typeChecker(currentScope); 
         typeChecker.visit(ctx->expr());
     }
-
 }
-

--- a/src/listener/TonDeclarationListener.cpp
+++ b/src/listener/TonDeclarationListener.cpp
@@ -35,7 +35,10 @@ void TonDeclarationListener::exitVarDecl(TonParser::VarDeclContext *ctx) {
 }
 
 void TonDeclarationListener::enterTrackDecl(TonParser::TrackDeclContext *ctx){
-    std::string trackName = ctx->ID(1)->getText();
+    // ZMIANA: Pobieramy timelineName z target, a trackName z jedynego wolnego ID
+    std::string timelineName = ctx->target()->ID(0)->getText(); 
+    std::string trackName = ctx->ID()->getText(); 
+
     int currentLine = ctx->getStart()->getLine();
     if (currentScope->existsLocally(trackName)) {
         int previousLine = currentScope->get(trackName);
@@ -180,7 +183,8 @@ void TonDeclarationListener::exitLoopStat(TonParser::LoopStatContext *ctx) {
 }
 
 void TonDeclarationListener::exitArrayOpStat(TonParser::ArrayOpStatContext *ctx) {
-    std::string varName = ctx->ID()->getText();
+    // ZMIANA: Pobieramy varName z target
+    std::string varName = ctx->target()->ID(0)->getText();
 
     if (!currentScope->exists(varName)) {
         size_t line = ctx->getStart()->getLine();
@@ -200,5 +204,6 @@ void TonDeclarationListener::exitArrayOpStat(TonParser::ArrayOpStatContext *ctx)
         TonTypeChecker typeChecker(currentScope);
         typeChecker.visit(ctx->expr());
     }
+
 }
 

--- a/src/listener/TonDeclarationListener.cpp
+++ b/src/listener/TonDeclarationListener.cpp
@@ -35,7 +35,6 @@ void TonDeclarationListener::exitVarDecl(TonParser::VarDeclContext *ctx) {
 }
 
 void TonDeclarationListener::enterTrackDecl(TonParser::TrackDeclContext *ctx){
-    // ZMIANA: Pobieramy timelineName z target, a trackName z jedynego wolnego ID
     std::string timelineName = ctx->target()->ID(0)->getText(); 
     std::string trackName = ctx->ID()->getText(); 
 
@@ -183,7 +182,7 @@ void TonDeclarationListener::exitLoopStat(TonParser::LoopStatContext *ctx) {
 }
 
 void TonDeclarationListener::exitArrayOpStat(TonParser::ArrayOpStatContext *ctx) {
-    // ZMIANA: Pobieramy varName z target
+
     std::string varName = ctx->target()->ID(0)->getText();
 
     if (!currentScope->exists(varName)) {
@@ -199,7 +198,7 @@ void TonDeclarationListener::exitArrayOpStat(TonParser::ArrayOpStatContext *ctx)
                                  ": Cannot perform array operations on type " + targetType + ".");
     }
 
-    // Jeśli to operacja APPEND, sprawdzamy też wyrażenie (np. zeby wyłapać błąd w 'APPEND 10 + "tekst" TO lista')
+    
     if (ctx->APPEND()) {
         TonTypeChecker typeChecker(currentScope);
         typeChecker.visit(ctx->expr());

--- a/src/typechecker/TonTypeChecker.cpp
+++ b/src/typechecker/TonTypeChecker.cpp
@@ -234,7 +234,7 @@ std::any TonTypeChecker::visitSliceExpr(TonParser::SliceExprContext *ctx) {
 
 
 std::any TonTypeChecker::visitPopExpr(TonParser::PopExprContext *ctx) {
-    std::string varName = ctx->ID()->getText();
+    std::string varName = ctx->target()->ID(0)->getText();
 
     if (!currentScope->exists(varName)) {
         size_t line = ctx->getStart()->getLine();
@@ -252,4 +252,33 @@ std::any TonTypeChecker::visitPopExpr(TonParser::PopExprContext *ctx) {
     // Tablice w Tøn mogą trzymać dowolny typ, więc w czasie kompilacji nie wiemy, co z niej wyjdzie.
     // Zwracamy "UNKNOWN", zostawiając weryfikację właściwemu Interpreterowi.
     return std::string("UNKNOWN");
+}
+
+std::any TonTypeChecker::visitArrayOpStat(TonParser::ArrayOpStatContext *ctx) {
+    // 1. We extract the array name using the new target rule structure
+    std::string varName = ctx->target()->ID(0)->getText();
+
+    // 2. Verify the array exists in the current scope
+    if (!currentScope->exists(varName)) {
+        size_t line = ctx->getStart()->getLine();
+        throw std::runtime_error("Type Error in line " + std::to_string(line) + 
+                                 ": Array '" + varName + "' is not defined.");
+    }
+
+    // 3. Verify that the target is actually an ARRAY
+    std::string targetType = currentScope->resolveType(varName);
+    if (targetType != "ARRAY") {
+        size_t line = ctx->getStart()->getLine();
+        throw std::runtime_error("Type Error in line " + std::to_string(line) + 
+                                 ": Array operation requires an ARRAY variable. Given: " + targetType);
+    }
+
+    // 4. If this is an APPEND operation, we must visit the expression being appended 
+    //    so the Type Checker can recursively validate it (e.g., catching errors inside the appended expr).
+    if (ctx->APPEND()) {
+         visit(ctx->expr());
+    }
+
+    // Array operations are statements, they don't "return" a type value themselves.
+    return {}; 
 }

--- a/src/typechecker/TonTypeChecker.cpp
+++ b/src/typechecker/TonTypeChecker.cpp
@@ -249,23 +249,19 @@ std::any TonTypeChecker::visitPopExpr(TonParser::PopExprContext *ctx) {
                                  ": POP requires an ARRAY variable. Given: " + targetType);
     }
 
-    // Tablice w Tøn mogą trzymać dowolny typ, więc w czasie kompilacji nie wiemy, co z niej wyjdzie.
-    // Zwracamy "UNKNOWN", zostawiając weryfikację właściwemu Interpreterowi.
     return std::string("UNKNOWN");
 }
 
 std::any TonTypeChecker::visitArrayOpStat(TonParser::ArrayOpStatContext *ctx) {
-    // 1. We extract the array name using the new target rule structure
+    
     std::string varName = ctx->target()->ID(0)->getText();
 
-    // 2. Verify the array exists in the current scope
     if (!currentScope->exists(varName)) {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Type Error in line " + std::to_string(line) + 
                                  ": Array '" + varName + "' is not defined.");
     }
 
-    // 3. Verify that the target is actually an ARRAY
     std::string targetType = currentScope->resolveType(varName);
     if (targetType != "ARRAY") {
         size_t line = ctx->getStart()->getLine();
@@ -273,12 +269,9 @@ std::any TonTypeChecker::visitArrayOpStat(TonParser::ArrayOpStatContext *ctx) {
                                  ": Array operation requires an ARRAY variable. Given: " + targetType);
     }
 
-    // 4. If this is an APPEND operation, we must visit the expression being appended 
-    //    so the Type Checker can recursively validate it (e.g., catching errors inside the appended expr).
     if (ctx->APPEND()) {
          visit(ctx->expr());
     }
 
-    // Array operations are statements, they don't "return" a type value themselves.
     return {}; 
 }

--- a/src/typechecker/TonTypeChecker.cpp
+++ b/src/typechecker/TonTypeChecker.cpp
@@ -1,8 +1,27 @@
 #include "typechecker/TonTypeChecker.h"
 
+template <typename T>
+static std::shared_ptr<Scope<T>> resolveElderScopeTC(std::shared_ptr<Scope<T>> currentScope, int elderCount, size_t line) {
+    auto targetScope = currentScope;
+    for (int i = 0; i < elderCount; ++i) {
+        if (targetScope->parent != nullptr) {
+            targetScope = targetScope->parent;
+        } else {
+            throw std::runtime_error("Type Error in line " + std::to_string(line) + ": 'ELDER::' reached beyond global scope.");
+        }
+    }
+    return targetScope;
+}
+
+
 std::any TonTypeChecker::visitTargetExpr(TonParser::TargetExprContext *ctx) {
+    int elderCount = ctx->target()->elderRef().size();
+    auto targetScope = resolveElderScopeTC(currentScope, elderCount, ctx->getStart()->getLine());
+    
     std::string baseVarName = ctx->target()->ID(0)->getText();
-    std::string type = currentScope->resolveType(baseVarName);
+   
+    std::string type = targetScope->resolveType(baseVarName); 
+    
     if (ctx->target()->ID().size() > 1) {
         return std::string("SOUND");
     }
@@ -234,15 +253,18 @@ std::any TonTypeChecker::visitSliceExpr(TonParser::SliceExprContext *ctx) {
 
 
 std::any TonTypeChecker::visitPopExpr(TonParser::PopExprContext *ctx) {
+    int elderCount = ctx->target()->elderRef().size();
+    auto targetScope = resolveElderScopeTC(currentScope, elderCount, ctx->getStart()->getLine());
+    
     std::string varName = ctx->target()->ID(0)->getText();
 
-    if (!currentScope->exists(varName)) {
+    if (!targetScope->exists(varName)) { 
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Type Error in line " + std::to_string(line) + 
                                  ": Array '" + varName + "' is not defined.");
     }
 
-    std::string targetType = currentScope->resolveType(varName);
+    std::string targetType = targetScope->resolveType(varName);
     if (targetType != "ARRAY") {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Type Error in line " + std::to_string(line) + 
@@ -253,16 +275,18 @@ std::any TonTypeChecker::visitPopExpr(TonParser::PopExprContext *ctx) {
 }
 
 std::any TonTypeChecker::visitArrayOpStat(TonParser::ArrayOpStatContext *ctx) {
+    int elderCount = ctx->target()->elderRef().size();
+    auto targetScope = resolveElderScopeTC(currentScope, elderCount, ctx->getStart()->getLine());
     
     std::string varName = ctx->target()->ID(0)->getText();
 
-    if (!currentScope->exists(varName)) {
+    if (!targetScope->exists(varName)) {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Type Error in line " + std::to_string(line) + 
                                  ": Array '" + varName + "' is not defined.");
     }
 
-    std::string targetType = currentScope->resolveType(varName);
+    std::string targetType = targetScope->resolveType(varName);
     if (targetType != "ARRAY") {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Type Error in line " + std::to_string(line) + 


### PR DESCRIPTION
Naprawa błędu z ::: Parser wcześniej głupiał i widział :: jako dwa osobne dwukropki. Zmieniłem kolejność reguł w gramatyce (Ton.g4) i teraz Lexer prawidłowo skleja je w jeden operator.

Skakanie o kilka poziomów w górę: Dodałem funkcję pomocniczą resolveScope, która pozwala na kaskadowe wspinanie się w górę (czyli działa np. parent::parent::zmienna).

Wsparcie dla list i osi czasu: Zmieniłem reguły w gramatyce tak, żeby parent:: działało nie tylko przy zwykłym przypisywaniu wartości, ale też przy operacjach na tablicach (APPEND, CLEAR, POP) i przy tworzeniu ścieżek w timeline (trackDecl).

Czystki w kodzie: Żeby projekt w ogóle ruszył i nie sypał błędami przy kompilacji, zaktualizowałem też Type Checker i Listener. Musiały dowiedzieć się, że teraz nazwy zmiennych wyciągamy z nowego węzła target, a nie bezpośrednio z ID.