### PR TITLE
fix: prevent !break and !continue outside of loops (#79)

### DIFF
--- a/examples/error_examples/error_break1.txt
+++ b/examples/error_examples/error_break1.txt
@@ -1,0 +1,7 @@
+$ TEST 1: !break poza pętla (powinien być błąd)
+!make INT x <- 42;
+!shout "Zmienna x wynosi: ", x;
+
+!break; $ Tu kompilator powinien natychmiast zaprotestować
+
+!shout "To się nigdy nie wypisze";

--- a/examples/error_examples/error_continue.txt
+++ b/examples/error_examples/error_continue.txt
@@ -1,0 +1,5 @@
+$ TEST 2: !continue poza pętla wewnątrz zwykłego bloku (powinien być błąd)
+{
+    !shout "Jesteśmy w zwykłym bloku kodu...";
+    !continue; $ Błąd! Blok to nie pętla!
+}

--- a/examples/example_others/example_correctloop.ton
+++ b/examples/example_others/example_correctloop.ton
@@ -1,0 +1,16 @@
+$ TEST 3: Poprawne działanie pętli z !break i !continue
+!shout "--- START TESTU ---";
+
+!loop < 3 TIMES > {
+    !shout "Start iteracji...";
+    !continue;
+    !shout "ERROR: To sie nigdy nie wypisze!";
+}
+
+!loop < INT k FROM 1 TO 5 > {
+    !shout "Wejscie do petli i natychmiastowy break!";
+    !break;
+    !shout "ERROR: To tez sie nie wypisze!";
+}
+
+!shout "--- KONIEC TESTU (Sukces) ---";

--- a/include/listener/TonDeclarationListener.h
+++ b/include/listener/TonDeclarationListener.h
@@ -7,6 +7,7 @@
 class TonDeclarationListener : public TonBaseListener {
     private:
         std::shared_ptr<Scope<int>> currentScope;
+        int loopLevel = 0;
     public:
         TonDeclarationListener(){
             currentScope = std::make_shared<Scope<int>>();
@@ -24,7 +25,13 @@ class TonDeclarationListener : public TonBaseListener {
         void exitFuncDef(TonParser::FuncDefContext *ctx) override;
         void exitReturnStat(TonParser::ReturnStatContext *ctx) override;
 
-        virtual void enterLoopStat(TonParser::LoopStatContext *ctx) override;
-        virtual void exitLoopStat(TonParser::LoopStatContext *ctx) override;
+
         void exitArrayOpStat(TonParser::ArrayOpStatContext *ctx) override;
+
+        void enterLoopStat(TonParser::LoopStatContext *ctx) override;
+        void exitLoopStat(TonParser::LoopStatContext *ctx) override;
+        void enterUntilStat(TonParser::UntilStatContext *ctx) override;
+        void exitUntilStat(TonParser::UntilStatContext *ctx) override;
+        void enterBreakStat(TonParser::BreakStatContext *ctx) override;
+        void enterContinueStat(TonParser::ContinueStatContext *ctx) override;
 };

--- a/src/listener/TonDeclarationListener.cpp
+++ b/src/listener/TonDeclarationListener.cpp
@@ -155,29 +155,6 @@ void TonDeclarationListener::exitBlock(TonParser::BlockContext *ctx){
     }
 }
 
-void TonDeclarationListener::enterLoopStat(TonParser::LoopStatContext *ctx) {
-    currentScope = std::make_shared<Scope<int>>(currentScope);
-
-    int currentLine = ctx->getStart()->getLine();
-    if (ctx->FROM()) {
-        std::string varName = ctx->ID()->getText();
-        std::string typeName = ctx->type()->getText();
-        
-        currentScope->define(varName, typeName, currentLine);
-    }
-    else if (ctx->ASSIGN()) {
-        std::string varName = ctx->ID()->getText();
-        std::string typeName = ctx->type()->getText();
-        
-        currentScope->define(varName, typeName, currentLine);
-    }
-}
-
-void TonDeclarationListener::exitLoopStat(TonParser::LoopStatContext *ctx) {
-    if (currentScope->parent) {
-        currentScope = currentScope->parent;
-    }
-}
 
 void TonDeclarationListener::exitArrayOpStat(TonParser::ArrayOpStatContext *ctx) {
     std::string varName = ctx->ID()->getText();
@@ -199,5 +176,56 @@ void TonDeclarationListener::exitArrayOpStat(TonParser::ArrayOpStatContext *ctx)
     if (ctx->APPEND()) {
         TonTypeChecker typeChecker(currentScope);
         typeChecker.visit(ctx->expr());
+    }
+}
+
+
+void TonDeclarationListener::enterLoopStat(TonParser::LoopStatContext *ctx) {
+    loopLevel++;
+    currentScope = std::make_shared<Scope<int>>(currentScope);
+
+    int currentLine = ctx->getStart()->getLine();
+    if (ctx->FROM()) {
+        std::string varName = ctx->ID()->getText();
+        std::string typeName = ctx->type()->getText();
+        
+        currentScope->define(varName, typeName, currentLine);
+    }
+    else if (ctx->ASSIGN()) {
+        std::string varName = ctx->ID()->getText();
+        std::string typeName = ctx->type()->getText();
+        
+        currentScope->define(varName, typeName, currentLine);
+    }
+}
+
+void TonDeclarationListener::exitLoopStat(TonParser::LoopStatContext *ctx) {
+    loopLevel--; 
+    if (currentScope->parent) {
+        currentScope = currentScope->parent;
+    }
+}
+
+void TonDeclarationListener::enterUntilStat(TonParser::UntilStatContext *ctx) {
+    loopLevel++;
+}
+
+void TonDeclarationListener::exitUntilStat(TonParser::UntilStatContext *ctx) {
+    loopLevel--;
+}
+
+void TonDeclarationListener::enterBreakStat(TonParser::BreakStatContext *ctx) {
+    if (loopLevel == 0) {
+        size_t line = ctx->getStart()->getLine();
+        throw std::runtime_error("Validation Error in line " + std::to_string(line) + 
+                                 ": '!break' statement is not allowed outside of a loop.");
+    }
+}
+
+void TonDeclarationListener::enterContinueStat(TonParser::ContinueStatContext *ctx) {
+    if (loopLevel == 0) {
+        size_t line = ctx->getStart()->getLine();
+        throw std::runtime_error("Validation Error in line " + std::to_string(line) + 
+                                 ": '!continue' statement is not allowed outside of a loop.");
     }
 }


### PR DESCRIPTION
Przeniesienie walidacji do Listenera: Do TonDeclarationListener dodałem licznik loopLevel. Przy wchodzeniu do pętli (!loop, until) zwiększamy go, a przy wychodzeniu zmniejszamy. Wiemy dokładnie, czy jesteśmy w pętli, czy nie.

Blokowanie przed uruchomieniem: Jeśli Listener napotka !break lub !continue, a licznik pętli wynosi 0, natychmiast przerywamy działanie programu z jasnym komunikatem błędu. Dzięki temu interpreter w ogóle nie zaczyna wykonywać kodu 

