### PR TITLE
Issue67/implicit conversions

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -79,10 +79,10 @@ Tøn supports a classic set of operators for logic and mathematics:
 
 ---
 
-## 4. Type Conversions
+## 4. Type Conversions  and Rules
 The language supports both explicit and implicit type conversions.
 
-### Implicit Conversions and Rules
+### Implicit Conversions
 Implicit conversions happen automatically in the background whenever the context requires it — most notably during variable assignments (e.g., assigning a `NUMERICAL` to an `INT` variable), passing arguments to functions, or evaluating mathematical/logical expressions.
 
 Tøn will perform the following conversions implicitly:
@@ -98,12 +98,31 @@ Additionaly, the language provides **cast** operator: `<NEW_TYPE>expression`. It
 * `<STRING> CHAR` *(creates a `STRING` of size one with the given `CHAR`)*
 * `<STRING> INT/NUMERICAL` *(constructs a `STRING` representation of the given number)*
 
-**:triangular_flag_on_post: NOT IMPLEMENTED YET: :triangular_flag_on_post:**
+**TODO :triangular_flag_on_post: NOT IMPLEMENTED YET: :triangular_flag_on_post:**
 * `<INT/NUMERICAL> STRING` *(creates a number from a given `STRING`)*
 
 > **Note:** `STRING` -> `INT/NUMERICAL` conversion will succeed only if the given `STRING` contains a valid number. Otherwise, the interpreter will produce a runtime error.
 
+### Casting in Practice
 
+To explicitly cast a value from one type to another, place the target type inside angle brackets `< >` directly before the expression or variable.
+
+Here is a short example demonstrating both implicit and explicit conversions in action:
+```ton
+$ Implicit conversion (INT is automatically promoted to NUMERICAL)
+!make NUMERICAL myNumber <- 42;
+
+$ Explicitly casting a NUMERICAL to a STRING
+!make STRING textNumber <- "34";
+!make INT number <- <INT>textNumber;
+
+$ 3. Explicitly casting a NUMERICAL down to an INT (truncates decimals)
+!make NUMERICAL price <- 19.99;
+!make INT flatPrice <- <INT>price;
+
+!shout number; $ output: 34
+!shout flatPrice;  $ output: 19
+```
 ---
 
 ## 4. Control Flow

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -79,6 +79,33 @@ Tøn supports a classic set of operators for logic and mathematics:
 
 ---
 
+## 4. Type Conversions
+The language supports both explicit and implicit type conversions.
+
+### Implicit Conversions and Rules
+Implicit conversions happen automatically in the background whenever the context requires it — most notably during variable assignments (e.g., assigning a `NUMERICAL` to an `INT` variable), passing arguments to functions, or evaluating mathematical/logical expressions.
+
+Tøn will perform the following conversions implicitly:
+* `INT` -> `NUMERICAL` *(type promotion - converts an integer to a floating-point number)*
+* `NUMERICAL` -> `INT` *(type demotion - performs **truncation** of the decimal part)*
+* `INT/NUMERICAL` -> `BOOL` *(evaluates to **FALSE** when number is exactly **0 / 0.0**, and **TRUE** otherwise)*
+* `BOOL` -> `INT/NUMERICAL` -> *(evaluates **0 / 0.0** when **FALSE** and **1 / 1.0** when **TRUE** to the number)*
+
+### Explicit Conversions
+Additionaly, the language provides **cast** operator: `<NEW_TYPE>expression`. It can be used to manually force any of the implicit conversions mentioned above, and also to perform the following:
+
+* `<CHAR> STRING` *(works only when given `STRING` has a length of exactly 1)*
+* `<STRING> CHAR` *(creates a `STRING` of size one with the given `CHAR`)*
+* `<STRING> INT/NUMERICAL` *(constructs a `STRING` representation of the given number)*
+
+**:triangular_flag_on_post: NOT IMPLEMENTED YET: :triangular_flag_on_post:**
+* `<INT/NUMERICAL> STRING` *(creates a number from a given `STRING`)*
+
+> **Note:** `STRING` -> `INT/NUMERICAL` conversion will succeed only if the given `STRING` contains a valid number. Otherwise, the interpreter will produce a runtime error.
+
+
+---
+
 ## 4. Control Flow
 Conditionals and loops in Tøn use angle brackets `< >` for their expressions.
 ### If / Otherwise Statements

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -97,8 +97,6 @@ Additionaly, the language provides **cast** operator: `<NEW_TYPE>expression`. It
 * `<CHAR> STRING` *(works only when given `STRING` has a length of exactly 1)*
 * `<STRING> CHAR` *(creates a `STRING` of size one with the given `CHAR`)*
 * `<STRING> INT/NUMERICAL` *(constructs a `STRING` representation of the given number)*
-
-**TODO :triangular_flag_on_post: NOT IMPLEMENTED YET: :triangular_flag_on_post:**
 * `<INT/NUMERICAL> STRING` *(creates a number from a given `STRING`)*
 
 > **Note:** `STRING` -> `INT/NUMERICAL` conversion will succeed only if the given `STRING` contains a valid number. Otherwise, the interpreter will produce a runtime error.

--- a/examples/example_others/example_conversions.ton
+++ b/examples/example_others/example_conversions.ton
@@ -1,0 +1,34 @@
+$ 1. Konwersje liczbowe: INT <-> NUMERICAL
+!make NUMERICAL ulamek <- 5;            $ Niejawna konwersja INT (5) na NUMERICAL (5.0)
+!make INT liczbaCalkowita <- 3.99;      $ Niejawna konwersja NUMERICAL (3.99) na INT (3 - ucięcie)
+
+!shout "Ulamek: ", ulamek;                $ Powinno wypisać 5.0
+!shout "Calkowita: ", liczbaCalkowita;    $ Powinno wypisać 3
+
+$ 2. Konwersje logiczno-liczbowe: INT/NUMERICAL <-> BOOL
+!make BOOL czyPrawda <- 42;             $ Niejawna konwersja INT (42) na BOOL (TRUE)
+!make BOOL czyFalsz <- 0.0;             $ Niejawna konwersja NUMERICAL (0.0) na BOOL (FALSE)
+!make INT zPrawdyNaInt <- TRUE;         $ Niejawna konwersja BOOL (TRUE) na INT (1)
+
+!shout "Prawda? ", czyPrawda;             $ Powinno wypisać TRUE
+!shout "Falsz? ", czyFalsz;               $ Powinno wypisać FALSE
+!shout "Z prawdy: ", zPrawdyNaInt;        $ Powinno wypisać 1
+
+$ 1. Rzutowanie liczb na tekst i znak (STRING, CHAR)
+!make STRING intNaTekst <- <STRING>123;
+!make STRING numNaTekst <- <STRING>45.67;
+!make CHAR tekstNaZnak <- <CHAR>"X";
+
+!shout "Liczba jako tekst: ", intNaTekst; $ Powinno wypisać 123
+!shout "Ułamek jako tekst: ", numNaTekst; $ Powinno wypisać 45.67
+!shout "Pierwszy znak: ", tekstNaZnak;    $ Powinno wypisać 'X'
+
+$ 2. Zabezpieczenie przed rzutowaniem za długiego tekstu na CHAR
+$ Poniższa linijka wywoła celowy błąd w czasie wykonania, jeśli odkomentujesz
+$ !make CHAR zlyZnak <- <CHAR>"Za dlugi tekst";
+
+$ 3. Rzutowanie tekstu na liczby (jeśli zaimplementowałeś)
+$ Sprawdźmy jak zachowuje się rzutowanie BOOL na NUMERICAL
+!make NUMERICAL zPrawdyNaNum <- <NUMERICAL>TRUE;
+
+!shout "Z prawdy na Num: ", zPrawdyNaNum; $ Powinno wypisać 1.0

--- a/include/interpreter/TonInterpreter.h
+++ b/include/interpreter/TonInterpreter.h
@@ -24,7 +24,7 @@ public:
 };
 class TonInterpreter: public TonBaseVisitor {
 private:
-    bool doTypesMatch(const std::string& expectedTypeName, const std::any& val);
+    bool coerceType(const std::string& expectedTypeName, std::any& val);
     std::string findSoundFontPath();
     tsf* soundFont = nullptr;
     std::unordered_map<std::string, Instrument> loadedInstruments;

--- a/include/typechecker/TonTypeChecker.h
+++ b/include/typechecker/TonTypeChecker.h
@@ -21,7 +21,28 @@ private:
         return ((types == "UNKNOWN") || ...);
     }
 
+
+
 public:
+    bool isConvertible(const std::string& expected, const std::string& given) {
+        if (expected == given || given == "UNKNOWN" || expected == "UNKNOWN") {
+            return true;
+        }
+        if ((expected == "INT" && given == "NUMERICAL") ||
+            (expected == "NUMERICAL" && given == "INT")) {
+            return true;
+        }
+        if ((expected == "INT" && given == "BOOL") ||
+            (expected == "BOOL" && given == "INT")) {
+            return true;
+        }
+        if ((expected == "NUMERICAL" && given == "BOOL") ||
+            (expected == "BOOL" && given == "NUMERICAL")) {
+            return true;
+        }
+        return false;
+    }
+
     TonTypeChecker(std::shared_ptr<Scope<int>> scope) : currentScope{scope} { };
 
     std::any visitIntValExpr(TonParser::IntValExprContext *ctx) override { return std::string("INT"); }

--- a/include/typechecker/TonTypeChecker.h
+++ b/include/typechecker/TonTypeChecker.h
@@ -24,6 +24,7 @@ private:
 
 
 public:
+
     bool isConvertible(const std::string& expected, const std::string& given) {
         if (expected == given || given == "UNKNOWN" || expected == "UNKNOWN") {
             return true;

--- a/src/interpreter/TonInterpreter.cpp
+++ b/src/interpreter/TonInterpreter.cpp
@@ -27,7 +27,7 @@ const std::unordered_set<std::string> TonInterpreter::SYNTHS = {
     "square"
 };
 
-bool TonInterpreter::doTypesMatch(const std::string &expectedTypeName, const std::any &value)
+bool TonInterpreter::coerceType(const std::string &expectedTypeName, std::any &value)
 {
     if (expectedTypeName == "INT" && value.type() == typeid(int)) return true;
     if (expectedTypeName == "NUMERICAL" && value.type() == typeid(double)) return true;
@@ -42,6 +42,47 @@ bool TonInterpreter::doTypesMatch(const std::string &expectedTypeName, const std
     if (expectedTypeName == "TRACK" && value.type() == typeid(Track)) return true;
     // edge case: empty strings or arrays that may come as empty `any` object.
     if (!value.has_value() && expectedTypeName != "VOID") return false;
+
+    // implicit conversions:
+    if (expectedTypeName == "INT") {
+        if (value.type() == typeid(double)) {
+            value = static_cast<int>(std::any_cast<double>(value));
+            return true;
+        }
+        if (value.type() == typeid(bool)) {
+            value = std::any_cast<bool>(value) ? 1 : 0;
+            return true;
+        }
+        if (value.type() == typeid(float)) {
+            value = static_cast<int>(std::any_cast<float>(value));
+            return true;
+        }
+    }
+    else if (expectedTypeName == "NUMERICAL") {
+        if (value.type() == typeid(int)) {
+            value = static_cast<double>(std::any_cast<int>(value));
+            return true;
+        }
+        if (value.type() == typeid(bool)) {
+            value = std::any_cast<bool>(value) ? 1.0 : 0.0;
+            return true;
+        }
+        if (value.type() == typeid(float)) {
+            value = static_cast<double>(std::any_cast<float>(value));
+            return true;
+        }
+    }
+    else if (expectedTypeName == "BOOL") {
+        if (value.type() == typeid(int)) {
+            value = (std::any_cast<int>(value) != 0); return true;
+        }
+        if (value.type() == typeid(double)) {
+            value = (std::any_cast<double>(value) != 0.0); return true;
+        }
+        if (value.type() == typeid(float)) {
+            value = (std::any_cast<float>(value) != 0.0f); return true;
+        }
+    }
     return false;
 }
 
@@ -153,7 +194,7 @@ std::any TonInterpreter::visitVarDecl(TonParser::VarDeclContext *ctx) {
 
     if (ctx->expr()) {
         value = visit(ctx->expr());
-        if (!doTypesMatch(typeName, value)) {
+        if (!coerceType(typeName, value)) {
             size_t line = ctx->getStart()->getLine();
             throw std::runtime_error("Line " + std::to_string(line) +
                 ": Cannot assign this value to a variable of type " +
@@ -260,7 +301,7 @@ std::any TonInterpreter::visitAssignment(TonParser::AssignmentContext *ctx) {
         }
         std::any rightSide = visit(ctx->expr());
         std::string declaredType = currentScope->resolveType(varName);
-        if (!doTypesMatch(declaredType, rightSide)) {
+        if (!coerceType(declaredType, rightSide)) {
             size_t line = ctx->getStart()->getLine();
             throw std::runtime_error("Line " + std::to_string(line) +
                                      ": Cannot assign this value to a variable of type " +
@@ -492,11 +533,11 @@ std::any TonInterpreter::visitCreateSoundExpr(TonParser::CreateSoundExprContext 
     std::any arg1 = visit(ctx->expr(0));
     std::any arg2 = visit(ctx->expr(1));
 
-    if (!doTypesMatch("NOTE", arg1)) {
+    if (!coerceType("NOTE", arg1)) {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Line " + std::to_string(line) + ": First argument of SOUND definition must be a NOTE.");
     }
-    if (!doTypesMatch("INT", arg2)) {
+    if (!coerceType("INT", arg2)) {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Line " + std::to_string(line) + ": Second argument of SOUND definition must be an INT.");
     }
@@ -508,7 +549,7 @@ std::any TonInterpreter::visitCreateSoundExpr(TonParser::CreateSoundExprContext 
     if (ctx->expr().size() > 2) {
         std::any arg3 = visit(ctx->expr(2));
 
-        if (!doTypesMatch("NUMERICAL", arg3) && !doTypesMatch("INT", arg3)) {
+        if (!coerceType("NUMERICAL", arg3) && !coerceType("INT", arg3)) {
             size_t line = ctx->getStart()->getLine();
             throw std::runtime_error("Line " + std::to_string(line) + ": Volume must be a number in range [0, 2].");
         }
@@ -1232,7 +1273,7 @@ std::any TonInterpreter::executeFunctionLogic(const std::string& funcName, const
         std::string paramName = funcdefctx->ID(i+1)->getText();
         std::any argval = evaluatedArgs[i];
 
-        bool typeMatch = doTypesMatch(paramType, argval);
+        bool typeMatch = coerceType(paramType, argval);
         if (!typeMatch) {
             currentScope = previousScope;
             this->currentStackDepth--;
@@ -1262,7 +1303,7 @@ std::any TonInterpreter::executeFunctionLogic(const std::string& funcName, const
                 throw std::runtime_error("Function '" + funcName + "' must return a value of type " + expectedReturnType + ".");
             }
 
-            bool typeMatch = doTypesMatch(expectedReturnType, result);
+            bool typeMatch = coerceType(expectedReturnType, result);
             if (!typeMatch) {
                 throw std::runtime_error("Function '" + funcName + "' returned wrong type. Expected " + expectedReturnType + ".");
             }
@@ -1523,6 +1564,5 @@ std::any TonInterpreter::visitLengthOfExpr(TonParser::LengthOfExprContext *ctx) 
 
     size_t line = ctx->getStart()->getLine();
     throw std::runtime_error("Line " + std::to_string(line) +
-    throw std::runtime_error("Runtime Error in line " + std::to_string(line) + 
                              ": LENGTH operator requires STRING, ARRAY, SOUND, TRACK, or TIMELINE.");
 }

--- a/src/interpreter/TonInterpreter.cpp
+++ b/src/interpreter/TonInterpreter.cpp
@@ -1483,12 +1483,14 @@ std::any TonInterpreter::visitCastExpr(TonParser::CastExprContext *ctx) {
 
     else if (targetType == "NUMERICAL") {
         if (val.type() == typeid(int)) return static_cast<double>(std::any_cast<int>(val));
+        if (val.type() == typeid(bool)) return val;
         if (val.type() == typeid(double)) return val;
     }
 
 
     else if (targetType == "BOOL") {
         if (val.type() == typeid(int)) return std::any_cast<int>(val) != 0;
+        if (val.type() == typeid(double)) return std::any_cast<int>(val) != 0;
         if (val.type() == typeid(bool)) return val;
     }
 

--- a/src/listener/TonDeclarationListener.cpp
+++ b/src/listener/TonDeclarationListener.cpp
@@ -26,7 +26,7 @@ void TonDeclarationListener::exitVarDecl(TonParser::VarDeclContext *ctx) {
         std::any result = typeChecker.visit(ctx->expr());
         std::string actualType = std::any_cast<std::string>(result);
 
-        if (expectedType != actualType && actualType != "UNKNOWN") {
+        if (!typeChecker.isConvertible(expectedType, actualType)) {
             size_t line = ctx->getStart()->getLine();
             throw std::runtime_error("Type Error in line " + std::to_string(line) +
                                      ": Cannot assign " + actualType + " to a variable of type " + expectedType + ".");

--- a/src/typechecker/TonTypeChecker.cpp
+++ b/src/typechecker/TonTypeChecker.cpp
@@ -334,11 +334,11 @@ std::any TonTypeChecker::visitCastExpr(TonParser::CastExprContext *ctx) {
     }
 
     else if (targetType == "NUMERICAL") {
-        if (exprType == "INT" || exprType == "NUMERICAL") return std::string("NUMERICAL");
+        if (exprType == "INT" || exprType == "NUMERICAL" || exprType == "BOOL") return std::string("NUMERICAL");
     }
    
     else if (targetType == "BOOL") {
-        if (exprType == "INT" || exprType == "BOOL") return std::string("BOOL");
+        if (exprType == "INT" || exprType == "BOOL" || exprType == "NUMERICAL") return std::string("BOOL");
     }
 
     else if (targetType == "STRING") {

--- a/src/typechecker/TonTypeChecker.cpp
+++ b/src/typechecker/TonTypeChecker.cpp
@@ -40,19 +40,21 @@ std::any TonTypeChecker::visitRelationalExpr(TonParser::RelationalExprContext *c
     if (hasUnknown(left, right)) {
         return std::string("BOOL");
     }
-    // TODO for now we are letting INT and NUMERICAL to be compared.
-    // Later on we should delete in because there will be implicit type conversion (int -> num)
+
+    if (isConvertible(left, right)) {
+        return std::string("BOOL");
+    }
+
     if (left == "SOUND" && right == "SOUND") {
         return std::string("BOOL");
     }
+
     if (left == "NOTE" && right == "NOTE") {
         return std::string("BOOL");
     }
-    if (left != right && !( (left == "INT" || left == "NUMERICAL") && (right == "INT" || right == "NUMERICAL") )) {
-        size_t line = ctx->getStart()->getLine();
-        throw std::runtime_error("Type Error in line " + std::to_string(line) + ": Cannot compare " + left + " with " + right);
-    }
-    return std::string("BOOL");
+
+    size_t line = ctx->getStart()->getLine();
+    throw std::runtime_error("Type Error in line " + std::to_string(line) + ": Cannot compare " + left + " with " + right);
 }
 
 std::any TonTypeChecker::visitUnaryExpr(TonParser::UnaryExprContext *ctx) {
@@ -193,20 +195,20 @@ std::any TonTypeChecker::visitCreateSoundExpr(TonParser::CreateSoundExprContext 
         return std::string("SOUND");
     }
 
-    if (arg1Type != "NOTE") {
+    if (!isConvertible("NOTE", arg1Type)) {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Line " + std::to_string(line) +
                                  ": First argument of CreateSound must be a NOTE. Given: " + arg1Type);
     }
     
-    if (arg2Type != "INT") {
+    if (!isConvertible("INT", arg2Type)) {
         size_t line = ctx->getStart()->getLine();
         throw std::runtime_error("Line " + std::to_string(line) +
                                  ": Second argument (duration) of CreateSound must be an INT. Given: " + arg2Type);
     }
 
     if (ctx->expr().size() > 2) {
-        if (arg3Type != "INT" && arg3Type != "NUMERICAL") {
+        if (!isConvertible("NUMERICAL", arg3Type)) {
             size_t line = ctx->getStart()->getLine();
             throw std::runtime_error("Line " + std::to_string(line) +
                                      ": Third argument (volume) of SOUND must be INT or NUMERICAL. Given: " + arg3Type);


### PR DESCRIPTION
Changed the method name from `DoTypeMatches` to `coerceType` since now its not only passive validation function but it actively performs implicit casts when it should and then validates the type.